### PR TITLE
Small addition to the usb stick mounts

### DIFF
--- a/ct/zwavejs2mqtt_container.sh
+++ b/ct/zwavejs2mqtt_container.sh
@@ -154,6 +154,7 @@ lxc.cgroup2.devices.allow: c 189:* rwm
 lxc.mount.entry: /dev/serial/by-id  dev/serial/by-id  none bind,optional,create=dir
 lxc.mount.entry: /dev/ttyUSB0       dev/ttyUSB0       none bind,optional,create=file
 lxc.mount.entry: /dev/ttyACM0       dev/ttyACM0       none bind,optional,create=file
+lxc.mount.entry: /dev/ttyACM1       dev/ttyACM1       none bind,optional,create=file
 EOF
 
 MOUNT=$(pct mount $CTID | cut -d"'" -f 2)


### PR DESCRIPTION
I already had a zigbee controller stick at dev/ttyACM0. And was searching for an eternity to figure out, that I had Zwave stick in dev/ttyACM1  to add as an mountpoint in lxc config file