### PR TITLE
Update vaultwarden-v3.sh

### DIFF
--- a/ct/vaultwarden-v3.sh
+++ b/ct/vaultwarden-v3.sh
@@ -87,10 +87,10 @@ function default_settings() {
         HN=$NSAPP
         echo -e "${DGN}Using Disk Size ${BGN}8${CL}${DGN}GB${CL}"
         DISK_SIZE="8"
-        echo -e "${DGN}Using ${BGN}4${CL}${DGN}vCPU${CL}"
-        CORE_COUNT="4"
-        echo -e "${DGN}Using ${BGN}4096${CL}${DGN}MiB RAM${CL}"
-        RAM_SIZE="4096"
+        echo -e "${DGN}Using ${BGN}1${CL}${DGN}vCPU${CL}"
+        CORE_COUNT="1"
+        echo -e "${DGN}Using ${BGN}512${CL}${DGN}MiB RAM${CL}"
+        RAM_SIZE="512"
         echo -e "${DGN}Using Bridge ${BGN}vmbr0${CL}"
         BRG="vmbr0"
         echo -e "${DGN}Using Static IP Address ${BGN}DHCP${CL}"
@@ -179,9 +179,9 @@ header_info
         echo -e "${DGN}Using CT ID ${BGN}$CT_ID${CL}"
         echo -e "${DGN}Using CT Name ${BGN}$HN${CL}"
         echo -e "${DGN}Using Disk Size ${BGN}$DISK_SIZE${CL}${DGN}GB${CL}"
-        echo -e "${YW}Allocate CPU cores, or Press [ENTER] for Default: 4 "
+        echo -e "${YW}Allocate CPU cores, or Press [ENTER] for Default: 1 "
         read CORE_COUNT
-        if [ -z $CORE_COUNT ]; then CORE_COUNT="4"; fi;
+        if [ -z $CORE_COUNT ]; then CORE_COUNT="1"; fi;
         echo -en "${DGN}Set Cores To ${BL}$CORE_COUNT${CL}${DGN}vCPU${CL}"
 echo -e " ${CM}${CL} \r"
 sleep 1
@@ -194,9 +194,9 @@ header_info
         echo -e "${DGN}Using CT Name ${BGN}$HN${CL}"
         echo -e "${DGN}Using Disk Size ${BGN}$DISK_SIZE${CL}${DGN}GB${CL}"
         echo -e "${DGN}Using ${BGN}${CORE_COUNT}${CL}${DGN}vCPU${CL}"
-        echo -e "${YW}Allocate RAM in MiB, or Press [ENTER] for Default: 4096 "
+        echo -e "${YW}Allocate RAM in MiB, or Press [ENTER] for Default: 512 "
         read RAM_SIZE
-        if [ -z $RAM_SIZE ]; then RAM_SIZE="4096"; fi;
+        if [ -z $RAM_SIZE ]; then RAM_SIZE="512"; fi;
         echo -en "${DGN}Set RAM To ${BL}$RAM_SIZE${CL}${DGN}MiB RAM${CL}"
 echo -e " ${CM}${CL} \n"
 sleep 1


### PR DESCRIPTION
Update default configuration for : vCPU (1 rather 4) and RAM (512Mib rather than 4096Mib), as written on website.

I think that actual defaults are overkill, as I have a full VM for Vaultwarden (on Debian 11, in docker alongside Portainer and Watchtower) with 1vCPU and 1024Mib RAM).