### PR TITLE
Update jellyfin-install.sh

### DIFF
--- a/setup/jellyfin-install.sh
+++ b/setup/jellyfin-install.sh
@@ -64,6 +64,7 @@ apt-get install -y curl &>/dev/null
 apt-get install -y sudo &>/dev/null
 apt-get install -y apt-transport-https &>/dev/null
 apt-get install -y software-properties-common &>/dev/null
+apt-get install -y ffmpeg &>/dev/null
 msg_ok "Installed Dependencies"
 
 msg_info "Setting Up Hardware Acceleration"  


### PR DESCRIPTION
Adding `ffmpeg` installation, so there is no error message (`This client isn't compatible with the media and the server isn't sending a compatible media format.`) while playing in web browser.

Referring to https://jellyfin.org/docs/general/administration/installing.html#ffmpeg-installation, and as we ere not on Debian or Debian derivative, we can just install `ffmpeg` and not the release built specifically for Jellyfin.

Tested, works fine.