### PR TITLE
Change Docker storage driver to fuse-overlayfs

### DIFF
--- a/ct/docker-v4.sh
+++ b/ct/docker-v4.sh
@@ -263,7 +263,7 @@ EOF
 msg_info "Starting LXC Container"
 pct start $CTID
 msg_ok "Started LXC Container"
-lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/rrense/Proxmox/storage-driver_to_fuse-overlayfs/setup/$var_install.sh)" || exit
+lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/setup/$var_install.sh)" || exit
 IP=$(pct exec $CTID ip a s dev eth0 | sed -n '/inet / s/\// /p' | awk '{print $2}')
 pct set $CTID -description "# ${APP} LXC
 ### https://tteck.github.io/Proxmox/

--- a/ct/docker-v4.sh
+++ b/ct/docker-v4.sh
@@ -234,9 +234,9 @@ function start_script() {
 clear
 start_script
 if [ "$CT_TYPE" == "1" ]; then
-  FEATURES="nesting=1,keyctl=1"
+  FEATURES="fuse=1,nesting=1,keyctl=1"
 else
-  FEATURES="nesting=1"
+  FEATURES="fuse=1,nesting=1"
 fi
 TEMP_DIR=$(mktemp -d)
 pushd $TEMP_DIR >/dev/null
@@ -263,7 +263,7 @@ EOF
 msg_info "Starting LXC Container"
 pct start $CTID
 msg_ok "Started LXC Container"
-lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/setup/$var_install.sh)" || exit
+lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/rrense/Proxmox/storage-driver_to_fuse-overlayfs/setup/$var_install.sh)" || exit
 IP=$(pct exec $CTID ip a s dev eth0 | sed -n '/inet / s/\// /p' | awk '{print $2}')
 pct set $CTID -description "# ${APP} LXC
 ### https://tteck.github.io/Proxmox/

--- a/setup/docker-install.sh
+++ b/setup/docker-install.sh
@@ -81,6 +81,7 @@ apt-get -y upgrade &>/dev/null
 msg_ok "Updated Container OS"
 
 msg_info "Installing Dependencies"
+apt-get install -y fuse-overlayfs &>/dev/null
 apt-get install -y curl &>/dev/null
 apt-get install -y sudo &>/dev/null
 msg_ok "Installed Dependencies"
@@ -98,6 +99,7 @@ DOCKER_CONFIG_PATH='/etc/docker/daemon.json'
 mkdir -p $(dirname $DOCKER_CONFIG_PATH)
 cat >$DOCKER_CONFIG_PATH <<'EOF'
 {
+  "storage-driver": "fuse-overlayfs",
   "log-driver": "journald"
 }
 EOF


### PR DESCRIPTION
## Description
Change the Docker storage driver from the default vfs to fuse-overlayfs. This will reduce disk space usage a lot.

Based on [Reducing storage usage for Docker in LXC](https://theorangeone.net/posts/docker-lxc-storage/) and [How to change the Docker storage driver](https://webdock.io/en/docs/how-guides/docker-guides/how-change-the-docker-storage-driver)

## Type of change

- [ ] Bug fix 
- [ ] New feature 
