### PR TITLE
Fix wrong mount point of renderD128 making Emby unrecognizable

### DIFF
--- a/ct/emby-v4.sh
+++ b/ct/emby-v4.sh
@@ -314,7 +314,7 @@ lxc.cgroup2.devices.allow: c 226:128 rwm
 lxc.cgroup2.devices.allow: c 29:0 rwm
 lxc.mount.entry: /dev/fb0 dev/fb0 none bind,optional,create=file
 lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir
-lxc.mount.entry: /dev/dri/renderD128 dev/renderD128 none bind,optional,create=file
+lxc.mount.entry: /dev/dri/renderD128 dev/dri/renderD128 none bind,optional,create=file
 EOF
 fi
 msg_info "Starting LXC Container"


### PR DESCRIPTION
# All Pull Requests should be made to the `pull-requests` branch

## Description

Fix wrong mount point of renderD128 making Emby unrecognizable

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
