### PR TITLE
Update to allow continue despite network issues

### DIFF
--- a/setup/paperless-ngx-install.sh
+++ b/setup/paperless-ngx-install.sh
@@ -61,8 +61,14 @@ msg_ok "Network Connected: ${BL}$(hostname -I)"
 set +e
 alias die=''
 if nc -zw1 8.8.8.8 443; then msg_ok "Internet Connected"; else
-	msg_error "Internet NOT Connected"
-	exit 1
+  msg_error "Internet NOT Connected"
+    read -r -p "Would you like to continue anyway? <y/N> " prompt
+    if [[ $prompt == "y" || $prompt == "Y" || $prompt == "yes" || $prompt == "Yes" ]]; then
+      echo -e " ⚠️  ${RD}Expect Issues Without Internet${CL}"
+    else
+      echo -e " 🖧  Check Network Settings"
+      exit 1
+    fi
 fi
 RESOLVEDIP=$(nslookup "github.com" | awk -F':' '/^Address: / { matched = 1 } matched { print $2}' | xargs)
 if [[ -z "$RESOLVEDIP" ]]; then msg_error "DNS Lookup Failure"; else msg_ok "DNS Resolved github.com to $RESOLVEDIP"; fi


### PR DESCRIPTION
Change to allow install to continue like it does for Postgres



## Description

Please include a summary of the change and/or which issue is fixed. 

Changes paperless-ngx network test to behave like some others do.

Fixes # NA

## Type of change

Please delete options that are not relevant.


- [ ] New feature 

