### PR TITLE
Fix grocy php installs

### DIFF
--- a/ct/grocy-v4.sh
+++ b/ct/grocy-v4.sh
@@ -309,7 +309,7 @@ bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/ct/c
 msg_info "Starting LXC Container"
 pct start $CTID
 msg_ok "Started LXC Container"
-lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/setup/$var_install.sh)" || exit
+lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/VR29/Proxmox/main/setup/$var_install.sh)" || exit
 IP=$(pct exec $CTID ip a s dev eth0 | sed -n '/inet / s/\// /p' | awk '{print $2}')
 pct set $CTID -description "# ${APP} LXC
 ### https://tteck.github.io/Proxmox/

--- a/ct/grocy-v4.sh
+++ b/ct/grocy-v4.sh
@@ -309,7 +309,7 @@ bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/ct/c
 msg_info "Starting LXC Container"
 pct start $CTID
 msg_ok "Started LXC Container"
-lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/VR29/Proxmox/main/setup/$var_install.sh)" || exit
+lxc-attach -n $CTID -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/setup/$var_install.sh)" || exit
 IP=$(pct exec $CTID ip a s dev eth0 | sed -n '/inet / s/\// /p' | awk '{print $2}')
 pct set $CTID -description "# ${APP} LXC
 ### https://tteck.github.io/Proxmox/

--- a/setup/grocy-install.sh
+++ b/setup/grocy-install.sh
@@ -96,10 +96,10 @@ sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://pa
 apt-get update &>/dev/null
 apt-get install -y php8.1 &>/dev/null
 apt-get install -y libapache2-mod-php8.1 &>/dev/null
-apt-get install -y php-sqlite3 &>/dev/null
-apt-get install -y php-gd &>/dev/null
-apt-get install -y php-intl &>/dev/null
-apt-get install -y php-mbstring &>/dev/null
+apt-get install -y php8.1-sqlite3 &>/dev/null
+apt-get install -y php8.1-gd &>/dev/null
+apt-get install -y php8.1-intl &>/dev/null
+apt-get install -y php8.1-mbstring &>/dev/null
 msg_ok "Installed PHP 8.1"
 
 msg_info "Installing grocy"


### PR DESCRIPTION
# All Pull Requests should be made to the `pull-requests` branch

## Description

Fixes bug of missing packages when installing grocy

Installed were:
php-sqlite3, php-gd, php-intl and php-mbstring

These need to be installed for the installer to properly work:
php8.1-sqlite3, php8.1-gd, php8.1-intl and php8.1-mbstring

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
