### PR TITLE
Update docker-install.sh

### DIFF
--- a/install/docker-install.sh
+++ b/install/docker-install.sh
@@ -105,7 +105,7 @@ chmod 755 /usr/local/bin/fuse-overlayfs
 cd ~
 echo -e '{\n  "storage-driver": "fuse-overlayfs",\n  "log-driver": "journald"\n}' > /etc/docker/daemon.json
 else
-echo -e '{\n  "log-driver": "journald"\n}' > /etc/docker/daemon.json
+echo -e '{\n  "storage-driver": "overlay2",\n   "log-driver": "journald"\n}' > /etc/docker/daemon.json
 fi
 sh <(curl -sSL https://get.docker.com) &>/dev/null
 msg_ok "Installed Docker $DOCKER_LATEST_VERSION"


### PR DESCRIPTION
overlay2 should be default not vfs which is set if there is no storage driver  in LXC ;/

# All Pull Requests should be made to the `pull-requests` branch

## Description

Please include a summary of the change and/or which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
