### PR TITLE
Update wireguard-v5.sh

### DIFF
--- a/ct/wireguard-v5.sh
+++ b/ct/wireguard-v5.sh
@@ -361,7 +361,7 @@ msg_ok "Installed WGDashboard"
 msg_info "Creating Service"
 service_path="/etc/systemd/system/wg-dashboard.service"
 echo "[Unit]
-After=netword.service
+After=systemd-networkd.service
 
 [Service]
 WorkingDirectory=/etc/wgdashboard/src


### PR DESCRIPTION
## Description

Fix typo in service file that prevents WGDashboard from starting on boot.

## Type of change

Bug fix 
