### PR TITLE
Update post-pve-install.sh

### DIFF
--- a/misc/post-pve-install.sh
+++ b/misc/post-pve-install.sh
@@ -109,7 +109,7 @@ fi
 read -r -p "Disable Subscription Nag? <y/N> " prompt
 if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_info "Disabling Subscription Nag"
-    echo "DPkg::Post-Invoke { \"dpkg -V proxmox-widget-toolkit | grep -q '/proxmoxlib\.js$'; if [ \$? -eq 1 ]; then { echo 'Removing subscription nag from UI...'; sed -i '/data.status/{s/\!//;s/active/NoMoreNagging/}' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js; }; fi\"; };" >/etc/apt/apt.conf.d/no-nag-script
+    echo "DPkg::Post-Invoke { \"dpkg -V proxmox-widget-toolkit | grep -q '/proxmoxlib\.js$'; if [ \$? -eq 1 ]; then { echo 'Removing subscription nag from UI...'; sed -i '/data\.status.*{/{s/\!//;s/active/NoMoreNagging/}' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js; }; fi\"; };" >/etc/apt/apt.conf.d/no-nag-script
     apt --reinstall install proxmox-widget-toolkit &>/dev/null
     msg_ok "Disabled Subscription Nag (Delete browser cache)"
 fi


### PR DESCRIPTION
## Description

Restrict Delete Subscription Nag function to only match the line with an opening brace, to prevent modifying lines unrelated to the subscription nag.

For v3.5.5 of proxmox-widget-toolkit, there are 4 lines in proxmoxlib.js which contains the text `data.status`. The current subscription nag script modifies two of them:

Line 520: `.data.status.toLowerCase() !== 'active') {` (the intended target)
Line 15645: `const subscription = !(!res || !res.data || res.data.status.toLowerCase() !== 'active');`

Line 15645 is merely for reporting subscription status and not to create the nag, and so shouldn't be modified by this script. This change adds the opening brace of line 520 as part of the regex so only that line is modified. The opening brace seems like a good text to match on, as it opens the function which creates the nag, so hopefully works across future versions of the widget toolkit.

Also change the period in `data.status` to be matched literally.

## Type of change

- [X] Bug fix