### PR TITLE
removed LXCIP part from grafana Menu

### DIFF
--- a/ct/alpine-adguard.sh
+++ b/ct/alpine-adguard.sh
@@ -52,11 +52,10 @@ function default_settings() {
 }
 
 function update_script() {
-LXCIP=$(ip a s dev eth0 | awk '/inet / {print $2}' | cut -d/ -f1)
 while true; do
   CHOICE=$(whiptail --title "SUPPORT" --menu "Select option" 11 58 2 \
     "1" "Update LXC OS" \
-    "2" "Manually Update $APP" 3>&2 2>&1 1>&3
+    "2" "Manually Update AdGuardHome" 3>&2 2>&1 1>&3
   )
   exit_status=$?
   if [ $exit_status == 1 ] ; then


### PR DESCRIPTION
$APP variable contains OS and APP in a string instead of just the APP (that is "old" stuff from debian scripts I know)

maybe a solution would be to get rid of debian at all for perfectly running alpine LXCs or let the user choose on installation if debian or alpine should be installed and then there is no need for the OS name in the LXC's hostname and even the variable called `APP`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix 
