### PR TITLE
fix EOF whitespace issue

### DIFF
--- a/misc/debian.func
+++ b/misc/debian.func
@@ -386,7 +386,7 @@ EOF
   cat <<EOF >>$LXC_CONFIG
 lxc.cgroup2.devices.allow: a
 lxc.cap.drop:
-EOF  
+EOF
   fi
   msg_info "Starting LXC Container"
   pct start "$CTID"


### PR DESCRIPTION
# All Pull Requests should be made to the `pull-requests` branch

## Description

EOF had trailing whitespace which results in a bash syntax error

Fixes #1221

## Type of change


- [x] Bug fix 
