### PR TITLE
Alpine > default Packages to simple func

### DIFF
--- a/install/alpine-adguard-install.sh
+++ b/install/alpine-adguard-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add nano
-$STD apk add mc
-$STD apk add openssh
-msg_ok "Installed Dependencies"
+#msg_info "Installing Dependencies"
+#msg_ok "Installed Dependencies"
 
 msg_info "Installing Alpine-AdGuard"
 VER=$(curl --silent -qI https://github.com/AdguardTeam/AdGuardHome/releases/latest | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}');

--- a/install/alpine-docker-install.sh
+++ b/install/alpine-docker-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+#msg_info "Installing Dependencies"
+#msg_ok "Installed Dependencies"
 
 msg_info "Installing Docker"
 $STD apk add docker

--- a/install/alpine-esphome-install.sh
+++ b/install/alpine-esphome-install.sh
@@ -12,13 +12,9 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
 msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
 $STD apk add git
 msg_ok "Installed Dependencies"
 

--- a/install/alpine-grafana-install.sh
+++ b/install/alpine-grafana-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+#msg_info "Installing Dependencies"
+#msg_ok "Installed Dependencies"
 
 msg_info "Installing Grafana"
 $STD apk add grafana

--- a/install/alpine-vaultwarden-install.sh
+++ b/install/alpine-vaultwarden-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
 msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
 $STD apk add openssl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Alpine-Vaultwarden"

--- a/install/alpine-whoogle-install.sh
+++ b/install/alpine-whoogle-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+#msg_info "Installing Dependencies"
+#msg_ok "Installed Dependencies"
 
 msg_info "Installing pip3 Package Manager"
 $STD apk add py3-pip

--- a/install/alpine-zigbee2mqtt-install.sh
+++ b/install/alpine-zigbee2mqtt-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+#msg_info "Installing Dependencies"
+#msg_ok "Installed Dependencies"
 
 msg_info "Installing Alpine-Zigbee2MQTT"
 $STD apk add zigbee2mqtt

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -106,6 +106,16 @@ update_os() {
   msg_ok "Updated Container OS"
 }
 
+default_packages() {
+  msg_info "Installing Default Packages"
+  $STD apk add newt
+  $STD apk add curl
+  $STD apk add nano
+  $STD apk add mc
+  $STD apk add openssh
+  msg_ok "Installed Default Packages"
+}
+
 motd_ssh() {
   echo "export TERM='xterm-256color'" >>/root/.bashrc
   echo -e "$APPLICATION LXC provided by https://tteck.github.io/Proxmox/\n" >/etc/motd


### PR DESCRIPTION
now only the real required apps must be installed and listed under "installing dependencies" :)

I used all your default app packages for the new function and run it directly after the OS update.
So we only need to install real app dependencies for the apps we want to install via the script

## Type of change

Please delete options that are not relevant.

- [X] New feature 
