### PR TITLE
Fix missing methods

### DIFF
--- a/install/heimdalldashboard-install.sh
+++ b/install/heimdalldashboard-install.sh
@@ -23,6 +23,7 @@ msg_info "Installing PHP"
 $STD apt-get install -y php
 $STD apt-get install -y php-sqlite3
 $STD apt-get install -y php-zip
+$STD apt-get install php7.4-xml
 msg_ok "Installed PHP"
 
 RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/Heimdall/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]')

--- a/install/heimdalldashboard-install.sh
+++ b/install/heimdalldashboard-install.sh
@@ -23,7 +23,7 @@ msg_info "Installing PHP"
 $STD apt-get install -y php
 $STD apt-get install -y php-sqlite3
 $STD apt-get install -y php-zip
-$STD apt-get install php7.4-xml
+$STD apt-get install -y php7.4-xml
 msg_ok "Installed PHP"
 
 RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/Heimdall/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]')


### PR DESCRIPTION
## Description

Some Heimdall apps use method simplexml_load_string() which depends on php-xml package. Since Heimdall uses php 7.4 I added such dependency.

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
