### PR TITLE
Added the argon2 change to Vaultwarden (1.28+) Script for ADMIN_TOKEN

### DIFF
--- a/ct/alpine-vaultwarden.sh
+++ b/ct/alpine-vaultwarden.sh
@@ -59,7 +59,7 @@ function update_script() {
     CHOICE=$(
       whiptail --title "SUPPORT" --menu "Select option" 11 58 2 \
         "1" "Update Vaultwarden" \
-        "2" "Show Admin Token" 3>&2 2>&1 1>&3
+        "2" "Reset Admin-Token" 3>&2 2>&1 1>&3
     )
     exit_status=$?
     if [ $exit_status == 1 ]; then
@@ -73,7 +73,22 @@ function update_script() {
       exit
       ;;
     2)
-      whiptail --title "ADMIN TOKEN" --msgbox "$(cat /etc/conf.d/vaultwarden | grep ADMIN_TOKEN | awk '{print substr($2, 13) }')" 7 68
+      if NEWTOKEN=$(whiptail --passwordbox "Setup your ADMIN_TOKEN (make it strong)" 10 58 3>&1 1>&2 2>&3); then
+        if [[ -z "$NEWTOKEN" ]]; then exit-script; fi      
+        ADMINTOKEN=$(echo -n ${NEWTOKEN} | argon2 "$(openssl rand -base64 32)" -e -id -k 19456 -t 2 -p 1)
+        if [[ -f /var/lib/vaultwarden/config.json ]]; then 
+          sed -i '/admin_token/d' /var/lib/vaultwarden/config.json
+          sed -i "2i\\  \"admin_token\": \"$ADMINTOKEN\"" /var/lib/vaultwarden/config.json
+        fi
+      fi
+      cat <<EOF >/etc/conf.d/vaultwarden
+export DATA_FOLDER=/var/lib/vaultwarden
+export WEB_VAULT_FOLDER=/var/lib/vaultwarden/web-vault
+export WEB_VAULT_ENABLED=true
+export ADMIN_TOKEN='$ADMINTOKEN'
+export ROCKET_ADDRESS=0.0.0.0
+EOF
+      rc-service vaultwarden restart
       clear
       exit
       ;;

--- a/install/alpine-vaultwarden-install.sh
+++ b/install/alpine-vaultwarden-install.sh
@@ -12,23 +12,32 @@ catch_errors
 setting_up_container
 network_check
 update_os
+default_packages
 
 msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
 $STD apk add openssl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
+$STD apk add argon2
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Alpine-Vaultwarden"
 $STD apk add vaultwarden
+ADMINTOKEN=''
+if NEWTOKEN=$(whiptail --passwordbox "Setup your ADMIN_TOKEN (make it strong)" 10 58 3>&1 1>&2 2>&3); then
+  if [[ ! -z "$NEWTOKEN" ]]; then
+    ADMINTOKEN=$(echo -n ${NEWTOKEN} | argon2 "$(openssl rand -base64 32)" -e -id -k 19456 -t 2 -p 1)
+  else
+    clear
+    echo -e "⚠  User didn't setup ADMIN_TOKEN, admin panel is disabled! \n"
+  fi
+else
+  clear
+  echo -e "⚠  User didn't setup ADMIN_TOKEN, admin panel is disabled! \n"
+fi
 cat <<EOF >/etc/conf.d/vaultwarden
 export DATA_FOLDER=/var/lib/vaultwarden
 export WEB_VAULT_FOLDER=/var/lib/vaultwarden/web-vault
 export WEB_VAULT_ENABLED=true
-export ADMIN_TOKEN=$(openssl rand -base64 48)
+export ADMIN_TOKEN='$ADMINTOKEN'
 export ROCKET_ADDRESS=0.0.0.0
 EOF
 $STD rc-service vaultwarden start

--- a/install/alpine-vaultwarden-install.sh
+++ b/install/alpine-vaultwarden-install.sh
@@ -12,10 +12,14 @@ catch_errors
 setting_up_container
 network_check
 update_os
-default_packages
 
 msg_info "Installing Dependencies"
+$STD apk add newt
+$STD apk add curl
 $STD apk add openssl
+$STD apk add openssh
+$STD apk add nano
+$STD apk add mc
 $STD apk add argon2
 msg_ok "Installed Dependencies"
 


### PR DESCRIPTION
## Description

The ADMIN_TOKEN should made hashed instead of plain-text. Further information can be found here: https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page#secure-the-admin_token

We get this on the `/admin` page as a warning on login.
![image](https://user-images.githubusercontent.com/17103076/230784112-ad06f829-d3c3-4a13-a12b-d58f61e8259d.png)

If we want to fix it with a already running installation, we just have to run the update script to setup a new or the old admin token. Then this will be hashed with the `owasp` preset and inserted on the right places of the config files.

Here a few screenshots during the setup:
![image](https://user-images.githubusercontent.com/17103076/230784304-8bdf8164-8e0b-43b9-90c9-0e3cca779cef.png)

This will be shown if a user doesn't setup an ADMIN_TOKEN during the installation :)
![image](https://user-images.githubusercontent.com/17103076/230784328-a489e50d-05c3-4be7-835c-9650712a16b4.png)

## Type of change

- [X] Bug fix 
- [X] New feature
