### PR TITLE
Fix for DNS lookup failing during wget command.

### DIFF
--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -54,12 +54,12 @@ function default_settings() {
 function update_script() {
 header_info
 if [[ ! -d /opt/AdGuardHome ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+wget -qL https://static.adguard.com/adguardhome/release/AdGuardHome_linux_amd64.tar.gz
 msg_info "Stopping AdguardHome"
 systemctl stop AdGuardHome
 msg_ok "Stopped AdguardHome"
 
 msg_info "Updating AdguardHome"
-wget -qL https://static.adguard.com/adguardhome/release/AdGuardHome_linux_amd64.tar.gz
 tar -xvf AdGuardHome_linux_amd64.tar.gz &>/dev/null
 mkdir -p adguard-backup
 cp -r /opt/AdGuardHome/AdGuardHome.yaml /opt/AdGuardHome/data adguard-backup/
@@ -74,7 +74,7 @@ msg_ok "Started AdguardHome"
 msg_info "Cleaning Up"
 rm -rf AdGuardHome_linux_amd64.tar.gz AdGuardHome adguard-backup
 msg_ok "Cleaned"
-msg_ok "Update Successfull"
+msg_ok "Update Successful"
 exit
 }
 


### PR DESCRIPTION
## Description

This simply moves the download command for the newest Adguard files to before shutting down Adguard.  Previously Adguard wouldn't be online to respond to the DNS query and if it were the only DNS available the download would fail.

Fixes https://github.com/tteck/Proxmox/issues/1121

## Type of change

- [X] Bug fix 

