### PR TITLE
ENH : point webdriver to 127.0.0.1:4444/wd/hub instead of browser-chr…

### DIFF
--- a/install/changedetection-install.sh
+++ b/install/changedetection-install.sh
@@ -34,6 +34,7 @@ After=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/changedetection
+Environment="WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub"
 ExecStart=changedetection.io -d /opt/changedetection -p 5000
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…ome:4444/wd/hub

cloud help for #948 #851

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

avoid referencing default external undefined webdriver host and instead use localhost ip.

Fixes #948 

## Type of change

Please delete options that are not relevant.

- [x] New feature 
