### PR TITLE
Update alpine-vaultwarden-install.sh

### DIFF
--- a/install/alpine-vaultwarden-install.sh
+++ b/install/alpine-vaultwarden-install.sh
@@ -25,23 +25,16 @@ msg_ok "Installed Dependencies"
 
 msg_info "Installing Alpine-Vaultwarden"
 $STD apk add vaultwarden
-sudo sed -i -e 's/# export ADMIN_TOKEN=.*/export ADMIN_TOKEN='\'''\''/' -e '/^# export ROCKET_ADDRESS=0\.0\.0\.0/s/^# //' -e 's|export WEB_VAULT_FOLDER=.*|export WEB_VAULT_FOLDER=/usr/share/webapps/vaultwarden-web/web-vault/|' -e 's|export WEB_VAULT_ENABLED=.*|export WEB_VAULT_ENABLED=true|' /etc/conf.d/vaultwarden
-msg_ok "Installed Alpine-Vaultwarden"
-
-WEBVAULT=$(curl -s https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')  
-curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/$WEBVAULT/bw_web_$WEBVAULT.tar.gz
-mkdir -p /usr/share/webapps/vaultwarden-web/
-
-msg_info "Downloading Web-Vault ${WEBVAULT}"
-$STD curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/$WEBVAULT/bw_web_$WEBVAULT.tar.gz
-$STD tar -xzf bw_web_$WEBVAULT.tar.gz -C /usr/share/webapps/vaultwarden-web/
-rm bw_web_$WEBVAULT.tar.gz
-msg_ok "Downloaded Web-Vault ${WEBVAULT}" 
-
-msg_info "Starting Alpine-Vaultwarden"
+$STD apk add vaultwarden-web-vault
+cat <<EOF >>/etc/conf.d/vaultwarden
+export ADMIN_TOKEN=''
+export WEB_VAULT_FOLDER=/usr/share/webapps/vaultwarden-web/
+export WEB_VAULT_ENABLED=true
+export ROCKET_ADDRESS=0.0.0.0
+EOF
 $STD rc-service vaultwarden start
 $STD rc-update add vaultwarden default
-msg_info "Started Alpine-Vaultwarden"
+msg_ok "Installed Alpine-Vaultwarden"
 
 motd_ssh
 customize


### PR DESCRIPTION
Now Webvault will work again :) You can read more about it here: https://gitlab.alpinelinux.org/alpine/aports/-/issues/15009#note_317523

I think you won't use any packages anymore on alpine that are not from the direct repo there? now you switched back to github releases?

this one here is the official way on how to achieve this with alpine packages for vaultwarden, sry that I'm confused again :/