### PR TITLE
Add rdtclient LXC script

### DIFF
--- a/ct/rdtclient.sh
+++ b/ct/rdtclient.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2023 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+             ____       ___            __
+   _________/ / /______/ (_)__  ____  / /_
+  / ___/ __  / __/ ___/ / / _ \/ __ \/ __/
+ / /  / /_/ / /_/ /__/ / /  __/ / / / /_
+/_/   \__,_/\__/\___/_/_/\___/_/ /_/\__/
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="RdtClient"
+var_disk="4"
+var_cpu="1"
+var_ram="1024"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -d /opt/rdtclient/ ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Updating $APP LXC"
+apt-get update &>/dev/null
+apt-get -y upgrade &>/dev/null
+msg_ok "Updated $APP LXC"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+         ${BL}http://${IP}:6500${CL} \n"

--- a/install/rdtclient-install.sh
+++ b/install/rdtclient-install.sh
@@ -20,16 +20,20 @@ $STD apt-get install -y mc
 $STD apt-get install -y unzip
 msg_ok "Installed Dependencies"
 
-msg_info "Installing rdtclient"
-wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+msg_info "Installing ASP.NET Core Runtime"
+wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb &>/dev/null
 rm packages-microsoft-prod.deb
 apt-get update &>/dev/null
 apt-get install -y dotnet-sdk-6.0 &>/dev/null
+msg_ok "Installed ASP.NET Core Runtime"
+msg_info "Installing rdtclient"
 wget -q https://github.com/rogerfar/rdt-client/releases/latest/download/RealDebridClient.zip
 unzip -qq RealDebridClient.zip -d /opt/rdtc
 mkdir -p /data/db/ # defaults for rdtclient
 mkdir -p /data/downloads # defaults for rdtclient
+msg_info "Installed rdtclient"
+msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/rdtc.service
 [Unit]
 Description=RdtClient Service
@@ -45,9 +49,8 @@ User=root
 WantedBy=multi-user.target
 EOF
 $STD systemctl daemon-reload
-$STD systemctl enable rdtc
-$STD systemctl start rdtc
-msg_ok "Installed rdtclient"
+$STD systemctl enable -q --now rdtc
+msg_ok "Created Service"
 
 motd_ssh
 customize

--- a/install/rdtclient-install.sh
+++ b/install/rdtclient-install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2023 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl
+$STD apt-get install -y sudo
+$STD apt-get install -y mc
+$STD apt-get install -y unzip
+msg_ok "Installed Dependencies"
+
+msg_info "Installing rdtclient"
+wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+dpkg -i packages-microsoft-prod.deb &>/dev/null
+rm packages-microsoft-prod.deb
+apt-get update &>/dev/null
+apt-get install -y dotnet-sdk-6.0 &>/dev/null
+wget -q https://github.com/rogerfar/rdt-client/releases/latest/download/RealDebridClient.zip
+unzip -qq RealDebridClient.zip -d /opt/rdtc
+mkdir -p /data/db/ # defaults for rdtclient
+mkdir -p /data/downloads # defaults for rdtclient
+cat <<EOF >/etc/systemd/system/rdtc.service
+[Unit]
+Description=RdtClient Service
+
+[Service]
+
+WorkingDirectory=/opt/rdtc
+ExecStart=/usr/bin/dotnet RdtClient.Web.dll
+SyslogIdentifier=RdtClient
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+$STD systemctl daemon-reload
+$STD systemctl enable rdtc
+$STD systemctl start rdtc
+msg_ok "Installed rdtclient"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get autoremove
+$STD apt-get autoclean
+msg_ok "Cleaned"

--- a/install/rdtclient-install.sh
+++ b/install/rdtclient-install.sh
@@ -21,15 +21,13 @@ $STD apt-get install -y unzip
 msg_ok "Installed Dependencies"
 
 msg_info "Installing ASP.NET Core Runtime"
-wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb
-dpkg -i packages-microsoft-prod.deb &>/dev/null
-rm packages-microsoft-prod.deb
-apt-get update &>/dev/null
-apt-get install -y dotnet-sdk-6.0 &>/dev/null
+$STD bash -c "$(wget --no-cache -qLO - https://dot.net/v1/dotnet-install.sh)"
+ln -s /root/.dotnet/dotnet /usr/bin/dotnet
 msg_ok "Installed ASP.NET Core Runtime"
 msg_info "Installing rdtclient"
 wget -q https://github.com/rogerfar/rdt-client/releases/latest/download/RealDebridClient.zip
 unzip -qq RealDebridClient.zip -d /opt/rdtc
+rm RealDebridClient.zip
 mkdir -p /data/db/ # defaults for rdtclient
 mkdir -p /data/downloads # defaults for rdtclient
 msg_info "Installed rdtclient"

--- a/install/rdtclient-install.sh
+++ b/install/rdtclient-install.sh
@@ -21,8 +21,11 @@ $STD apt-get install -y unzip
 msg_ok "Installed Dependencies"
 
 msg_info "Installing ASP.NET Core Runtime"
-$STD bash -c "$(wget --no-cache -qLO - https://dot.net/v1/dotnet-install.sh)"
-ln -s /root/.dotnet/dotnet /usr/bin/dotnet
+wget -q https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb
+$STD dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+$STD apt-get update
+$STD apt-get install -y dotnet-sdk-6.0
 msg_ok "Installed ASP.NET Core Runtime"
 msg_info "Installing rdtclient"
 wget -q https://github.com/rogerfar/rdt-client/releases/latest/download/RealDebridClient.zip


### PR DESCRIPTION
## Description

Add rdtclient LXC script (https://github.com/rogerfar/rdt-client)

Fixes # (issue)

- Addressed all comments
- Change how .NET is installed, now uses official m$ script installation method for debian

## Type of change

Please delete options that are not relevant.

- [ ] New Script
