### PR TITLE
Update alpine-install.func

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -23,7 +23,8 @@ verb_ip6() {
   silent() { "$@" >/dev/null 2>&1; }
   if [ "$DISABLEIPV6" == "yes" ]; then
     echo "net.ipv6.conf.all.disable_ipv6 = 1" >>/etc/sysctl.conf
-    $STD sysctl -p
+    $STD rc-update add sysctl
+    $STD /etc/init.d/sysctl start
   fi
 }
 
@@ -117,7 +118,6 @@ motd_ssh() {
 }
 
 customize() {
-  $STD sysctl -p
   if [[ "$PASSWORD" == "" ]]; then
   msg_info "Customizing Container"
   bash -c "passwd -d root" >/dev/null 2>&1


### PR DESCRIPTION
Remove sysctl -p from customize, as it runs already if ipv6 is disabled Add/start sysctl service if ipv6 is disabled.

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Use the sysctl service of Alpine to make ipv6 disables stick after reboots.
Doing so runs successfully but throws some errors on setting kernel parameters, as they are readonly:
```
 * Configuring kernel parameters ...sysctl: error setting key 'kernel.panic': Read-only file system
sysctl: error setting key 'fs.protected_hardlinks': Read-only file system
sysctl: error setting key 'fs.protected_symlinks': Read-only file system
sysctl: error setting key 'kernel.unprivileged_bpf_disabled': Read-only file system
 [ ok ]
```

I am quite new to Alpine and OpenRC, though, so please reject if you think the above is not harmless :)

In particular, I wonder how this would play with Privileged containers... I would expect Proxmox not to allow them to change kernel parameters, but I have never used them, so I really don't know.

Fixes #1688

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix 
