### PR TITLE
Update monitor-all.sh to restart virtual machines instead of resetting

### DIFF
--- a/misc/monitor-all.sh
+++ b/misc/monitor-all.sh
@@ -73,12 +73,13 @@ while true; do
       else
         # It is a virtual machine
         if qm status $instance | grep -q "status: running"; then
-          echo "$(date): VM $instance is not responding, resetting..."
-          qm reset $instance >/dev/null 2>&1
+          echo "$(date): VM $instance is not responding, restarting..."
+          qm stop $instance >/dev/null 2>&1
+          sleep 5
         else
-          qm start $instance >/dev/null 2>&1
           echo "$(date): VM $instance is not running, starting..."
         fi
+        qm start $instance >/dev/null 2>&1
       fi
     fi
   done


### PR DESCRIPTION
## Description

Resetting a virtual machine may not work if the virtual machine is frozen/stuck. (Home Assistant OS tends to get into this state sometimes and resetting it does nothing.)

Restarting the VM by stopping it and starting it seems to resolve the issue.

## Type of change

- [X] Bug fix 
