### PR TITLE
Replace deprecated Node.js setup script with manual setup

### DIFF
--- a/ct/cronicle.sh
+++ b/ct/cronicle.sh
@@ -75,13 +75,7 @@ apt-get install -y g++ &>/dev/null
 apt-get install -y gcc &>/dev/null
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-bash <(curl -fsSL https://deb.nodesource.com/setup_16.x) &>/dev/null
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-apt-get install -y nodejs &>/dev/null
-msg_ok "Installed Node.js"
+install_nodejs 16
 
 msg_info "Installing Cronicle Worker"
 mkdir -p /opt/cronicle

--- a/install/changedetection-install.sh
+++ b/install/changedetection-install.sh
@@ -53,15 +53,7 @@ $STD apt-get install -y \
   python3-pip
 msg_ok "Updated Python3"
 
-msg_info "Setting up Node.js Repository"
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Change Detection"
 mkdir /opt/changedetection

--- a/install/homarr-install.sh
+++ b/install/homarr-install.sh
@@ -20,13 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Yarn"
 $STD npm install -g yarn

--- a/install/homepage-install.sh
+++ b/install/homepage-install.sh
@@ -18,16 +18,16 @@ $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
 $STD apt-get install -y git
+$STD apt-get install -y make
+$STD apt-get install -y g++
+$STD apt-get install -y gcc
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
+install_nodejs 18
 
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs git make g++ gcc
+msg_info "Installing pnpm"
 $STD npm install -g pnpm
-msg_ok "Installed Node.js"
+msg_ok "Installed pnpm"
 
 msg_info "Installing Homepage (Patience)"
 cd /opt

--- a/install/jellyseerr-install.sh
+++ b/install/jellyseerr-install.sh
@@ -20,13 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Yarn"
 $STD npm install -g yarn

--- a/install/n8n-install.sh
+++ b/install/n8n-install.sh
@@ -19,13 +19,7 @@ $STD apt-get install -y sudo
 $STD apt-get install -y mc
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing n8n (Patience)"
 $STD npm install --global n8n

--- a/install/node-red-install.sh
+++ b/install/node-red-install.sh
@@ -20,13 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Node-Red"
 $STD npm install -g --unsafe-perm node-red

--- a/install/overseerr-install.sh
+++ b/install/overseerr-install.sh
@@ -20,13 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Yarn"
 $STD npm install -g yarn

--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -28,13 +28,7 @@ $STD apt-get install -y ffmpeg
 $STD apt-get install -y libheif1
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get -y install nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Golang"
 set +o pipefail

--- a/install/scrypted-install.sh
+++ b/install/scrypted-install.sh
@@ -62,13 +62,7 @@ $STD apt-get -y install \
     gstreamer1.0-alsa
 msg_ok "Installed GStreamer"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Updating Python3"
 $STD apt-get install -y \

--- a/install/shinobi-install.sh
+++ b/install/shinobi-install.sh
@@ -28,13 +28,7 @@ $STD apt-get install -y make zip net-tools
 $STD apt-get install -y gcc g++ cmake
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing FFMPEG"
 $STD apt-get install -y ffmpeg

--- a/install/uptimekuma-install.sh
+++ b/install/uptimekuma-install.sh
@@ -20,13 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD sudo apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Installing Uptime Kuma"
 $STD git clone https://github.com/louislam/uptime-kuma.git

--- a/install/wikijs-install.sh
+++ b/install/wikijs-install.sh
@@ -20,13 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_16.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 16
 
 msg_info "Installing Wiki.js"
 mkdir -p /opt/wikijs

--- a/install/zigbee2mqtt-install.sh
+++ b/install/zigbee2mqtt-install.sh
@@ -23,13 +23,7 @@ $STD apt-get install -y g++
 $STD apt-get install -y gcc
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-$STD bash <(curl -fsSL https://deb.nodesource.com/setup_18.x)
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_nodejs 18
 
 msg_info "Setting up Zigbee2MQTT Repository"
 $STD git clone https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt

--- a/misc/install.func
+++ b/misc/install.func
@@ -117,6 +117,22 @@ update_os() {
   msg_ok "Updated Container OS"
 }
 
+# This function sets up the Node.js repository and installs Node.js
+# Takes one argument: the Node.js version to install
+install_nodejs() {
+  local NODE_VERSION="$1"
+  msg_info "Setting up Node.js Repository"
+  $STD apt-get install -y ca-certificates curl gnupg
+  $STD mkdir -p /etc/apt/keyrings
+  $STD curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  $STD echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+  $STD apt-get update
+  msg_ok "Set up Node.js Repository"
+  msg_info "Installing Node.js"
+  $STD apt-get install -y nodejs
+  msg_ok "Installed Node.js"
+}
+
 # This function modifies the message of the day (motd) and SSH settings
 motd_ssh() {
   echo "export TERM='xterm-256color'" >>/root/.bashrc


### PR DESCRIPTION
I followed the instructions at https://github.com/nodesource/distributions#installation-instructions

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

I saw the deprecation warning in the logs while running the Change Detection LXC script in verbose mode. I used a regex search and replace in VS Code to replace all instances of the setup script with some manual commands.

I haven't tested all the scripts, but I will try it now with the Change Detection LXC script.

Fixes #1748 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
