### PR TITLE
Update pialert-install.sh

### DIFF
--- a/install/pialert-install.sh
+++ b/install/pialert-install.sh
@@ -38,6 +38,7 @@ $STD apt-get -y install \
   php-cgi \
   php-fpm \
   php-curl \
+  php-xml \
   php-sqlite3
 $STD lighttpd-enable-mod fastcgi-php
 service lighttpd force-reload


### PR DESCRIPTION
Update php dependencies.
This extension is necessary to determine the download link of the Ookla speedtest client.