### PR TITLE
Fix for Imagick on Overview page

### DIFF
--- a/install/alpine-nextcloud-install.sh
+++ b/install/alpine-nextcloud-install.sh
@@ -31,6 +31,7 @@ $STD apk add php82-fpm
 $STD apk add php82-sysvsem
 $STD apk add php82-pecl-smbclient
 $STD apk add php82-pecl-imagick
+$STD apk add php82-pecl-vips
 $STD apk add php82-exif
 $STD apk add redis
 msg_ok "Installed PHP/Redis"


### PR DESCRIPTION
Fix for this here:
![image](https://github.com/tteck/Proxmox/assets/17103076/aeeadef4-acc1-4955-8b38-7f1277ceb1ea)

`php82-pecl-vips` package was missing for that.

## Type of change

- [X] Bug fix 
