### PR TITLE
Alpine-Nextcloud: added option for FTP Support

### DIFF
--- a/install/alpine-nextcloud-install.sh
+++ b/install/alpine-nextcloud-install.sh
@@ -29,6 +29,7 @@ $STD apk add php82-redis
 $STD apk add php82-apcu
 $STD apk add php82-fpm
 $STD apk add php82-sysvsem
+$STD apk add php82-ftp
 $STD apk add php82-pecl-smbclient
 $STD apk add php82-pecl-imagick
 $STD apk add php82-pecl-vips


### PR DESCRIPTION
## Description

FTP can be setup as external storage afterwards.
Error message will disappear on external storage as well:
![image](https://github.com/tteck/Proxmox/assets/17103076/7a55df0f-befa-4c58-bff6-a5937138ea98)

## Type of change

- [X] Bug fix 