### PR TITLE
Update pialert-install.sh

### DIFF
--- a/install/pialert-install.sh
+++ b/install/pialert-install.sh
@@ -51,6 +51,7 @@ $STD apt-get -y install \
 $STD pip3 install mac-vendor-lookup
 $STD pip3 install fritzconnection
 $STD pip3 install cryptography
+$STD pip3 install pyunifi
 msg_ok "Installed Python Dependencies"
 
 msg_info "Installing Pi.Alert"


### PR DESCRIPTION
Bugfix for UniFi Support.

The error was discussed here. https://github.com/leiweibau/Pi.Alert/issues/185 
With the next update, I am optimistic that it will now run. However, since I don't have a UniFi system myself, I can't test it. 