### PR TITLE
Update update-lxcs.sh

### DIFF
--- a/misc/update-lxcs.sh
+++ b/misc/update-lxcs.sh
@@ -67,7 +67,7 @@ function update_container() {
   alpine) pct exec "$container" -- ash -c "apk update && apk upgrade" ;;
   archlinux) pct exec "$container" -- bash -c "pacman -Syyu --noconfirm" ;;
   fedora | rocky | centos | alma) pct exec "$container" -- bash -c "dnf -y update && dnf -y upgrade" ;;
-  ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt list --upgradable && apt-get -y dist-upgrade" ;;
+  ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt list --upgradable && apt-get -yq dist-upgrade" ;;
   esac
 }
 


### PR DESCRIPTION
Add -q to apt-get to avoid terminal noise in the logs

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Logs contain progress bar spam from apt-get, making them difficult to parse. Adding a `-q` to the apt-get command will still log details but disable the progress bar output into the log files. Example of the issue from the log file:

```
Fetched 1,634 kB in 1s (2,009 kB/s)
(Reading database ... ^M(Reading database ... 5%^M(Reading database ... 10%^M(Reading database ... 15%^M(Reading database ... 20%^M(Reading database ... 25%^M(Reading database ... 30%^M(Reading database ... 35%^M(Reading database ... 40%^M(Reading database ... 45%^M(Reading database ... 50%^M(Reading database ... 55%^M(Reading database ... 60%^M(Reading database ... 65%^M(Reading database ... 70%^M(Reading database ... 75%^M(Reading database ... 80%^M(Reading database ... 85%^M(Reading database ... 90%^M(Reading database ... 95%^M(Reading database ... 100%^M(Reading database ... 30129 files and directories currently installed.)
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
