### PR TITLE
Update syncthing-install.sh

### DIFF
--- a/install/syncthing-install.sh
+++ b/install/syncthing-install.sh
@@ -21,7 +21,7 @@ $STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Syncthing"
-curl -s -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg
+curl -sL -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg
 sh -c 'echo "deb [signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable" > /etc/apt/sources.list.d/syncthing.list'
 $STD apt-get update
 $STD apt-get install -y syncthing


### PR DESCRIPTION
Fix "301 Moved Permanently" for curl

Doesn't complete LXC installation.

```
? Installed Dependencies
+ msg_info 'Installing Syncthing'
+ local 'msg=Installing Syncthing'
+ echo -ne ' - \033[33mInstalling Syncthing...'
 - Installing Syncthing...+ curl -s -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg
+ sh -c 'echo "deb [signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable" > /etc/apt/sources.list.d/syncthing.list'
+ apt-get update
Сущ:1 http://security.debian.org bullseye-security InRelease
Сущ:2 http://deb.debian.org/debian bullseye InRelease                                                 
Сущ:3 http://deb.debian.org/debian bullseye-updates InRelease                                         
Пол:4 https://apt.syncthing.net syncthing InRelease [15,1 kB]                                         
Ошб:4 https://apt.syncthing.net syncthing InRelease
  Следующие подписи не могут быть проверены, так как недоступен открытый ключ: NO_PUBKEY D26E6ED000654A3E
Чтение списков пакетов… Готово
W: Ошибка GPG: https://apt.syncthing.net syncthing InRelease: Следующие подписи не могут быть проверены, так как недоступен открытый ключ: NO_PUBKEY D26E6ED000654A3E
E: Репозиторий «https://apt.syncthing.net syncthing InRelease» не подписан.
N: Обновление из этого репозитория нельзя выполнить безопасным способом, поэтому по умолчанию он отключён.
N: Информацию о создании репозитория и настройках пользователя смотрите в справочной странице apt-secure(8).
++ error_handler 26 '$STD apt-get update'
++ local exit_code=100
++ local line_number=26
++ local 'command=$STD apt-get update'
++ local 'error_message=\033[01;31m[ERROR]\033[m in line \033[01;31m26\033[m: exit code \033[01;31m100\033[m: while executing command \033[33m$STD apt-get update\033[m'
++ echo -e '\n\033[01;31m[ERROR]\033[m in line \033[01;31m26\033[m: exit code \033[01;31m100\033[m: while executing command \033[33m$STD apt-get update\033[m'
```
When https://syncthing.net/release-key.gpg is downloaded, a “301 Moved Permanently” redirect occurs.
Therefore, instead of the key, the server response is downloaded in the form of html.
```
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
```

In order for curl to handle redirects correctly, you need to add the **-L** option.
