### PR TITLE
Update unifi to mongodb 4.4 and jre 17

### DIFF
--- a/install/unifi-install.sh
+++ b/install/unifi-install.sh
@@ -18,28 +18,30 @@ $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
 $STD apt-get install -y apt-transport-https
+$STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-if [[ "$PCT_OSVERSION" == "12" ]]; then
-  echo -e "deb http://ftp.debian.org/debian bullseye main" >/etc/apt/sources.list.d/openjdk-11-jre-headless.list
-  $STD apt-get update
-fi
-
 msg_info "Installing OpenJDK"
-$STD apt-get install -y openjdk-11-jre-headless
-$STD apt-mark hold openjdk-11-*
+#$STD apt-get install -y openjdk-17-jre-headless
+#$STD apt-mark hold openjdk-17-*
+wget -qO- https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg >/dev/null 2>&1
+echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main' > /etc/apt/sources.list.d/adoptium.list
+$STD apt-get update
+$STD apt-get install -y temurin-17-jre
 msg_ok "Installed OpenJDK"
 
 msg_info "Installing MongoDB"
 wget -qL http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
 $STD dpkg -i libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
-wget -qL https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/3.6/multiverse/binary-amd64/mongodb-org-server_3.6.23_amd64.deb
-$STD dpkg -i mongodb-org-server_3.6.23_amd64.deb
+wget -qO- https://pgp.mongodb.com/server-4.4.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/mongodb-server-4.4.gpg >/dev/null 2>&1
+echo 'deb [ arch=amd64 signed-by=/etc/apt/trusted.gpg.d/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main' >/etc/apt/sources.list.d/mongodb-org-4.4.list
+$STD apt-get update
+$STD apt-get install -y mongodb-org
 msg_ok "Installed MongoDB"
 
 msg_info "Installing UniFi Network Application"
 wget -qO /etc/apt/trusted.gpg.d/unifi-repo.gpg https://dl.ui.com/unifi/unifi-repo.gpg
-echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' >/etc/apt/sources.list.d/100-ubnt-unifi.list
+echo 'deb [ arch=amd64 signed-by=/etc/apt/trusted.gpg.d/unifi-repo.gpg] https://www.ui.com/downloads/unifi/debian stable ubiquiti' >/etc/apt/sources.list.d/100-ubnt-unifi.list
 $STD apt-get update
 $STD apt-get install -y unifi
 msg_ok "Installed UniFi Network Application"
@@ -48,7 +50,7 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-rm -rf mongodb-org-server_3.6.23_amd64.deb libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb /etc/apt/sources.list.d/openjdk-11-jre-headless.list
+rm -rf libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
 $STD apt-get autoremove
 $STD apt-get autoclean
 msg_ok "Cleaned"


### PR DESCRIPTION
## Description
With [UniFi-Network-Application-8-0-7](https://community.ui.com/releases/UniFi-Network-Application-8-0-7/7818b9df-4845-4c82-ba3c-1218e61010d4) released that support newer jre and mongodb. Intention with this is to remove some of the publicly known vulnerabilities and use components that have a longer life cycle. 

## Type of change
Updated mongodb to 4.4 ( But still  [openssl 1.1.1](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/) is needed even if it's expired. Also mongo 4.4 is officially supported on Debian 11!  
Updated to JRE 17 from 11, I have selected Temurin ( But debian 12 orginal is commented out if that is better)
