### PR TITLE
Randomize the PiVPN subnet

### DIFF
--- a/install/wireguard-install.sh
+++ b/install/wireguard-install.sh
@@ -22,11 +22,12 @@ msg_ok "Installed Dependencies"
 
 msg_info "Installing WireGuard (using pivpn.io)"
 OPTIONS_PATH='/options.conf'
-cat >$OPTIONS_PATH <<'EOF'
+SUBNET=$(printf %d.%d.%d.%d 10 $((RANDOM % 256)) $((RANDOM % 256)) 0)
+cat >$OPTIONS_PATH <<EOF
 IPv4dev=eth0
 install_user=root
 VPN=wireguard
-pivpnNET=10.6.0.0
+pivpnNET=$SUBNET
 subnetClass=24
 ALLOWED_IPS="0.0.0.0/0, ::0/0"
 pivpnMTU=1420


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Instead of hard coding the PiVPN subnet, use a randomized private subnet. Best practice and necessary when simultaneously connecting to multiple locations.

## Type of change

Please delete options that are not relevant.

- [ ] New feature 
