### PR TITLE
fix: install Debian 12 version of MS deps, add libmsquic

### DIFF
--- a/install/technitiumdns-install.sh
+++ b/install/technitiumdns-install.sh
@@ -13,19 +13,14 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
-msg_ok "Installed Dependencies"
 
-msg_info "Installing ASP.NET Core Runtime"
-wget -q https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+msg_info "Installing Dependencies and ASP.NET Core Runtime"
+wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 $STD dpkg -i packages-microsoft-prod.deb
 rm -rf packages-microsoft-prod.deb
 $STD apt-get update
-$STD apt-get install -y aspnetcore-runtime-7.0
-msg_ok "Installed ASP.NET Core Runtime"
+$STD apt-get install -y aspnetcore-runtime-7.0 curl sudo mc libmsquic
+msg_ok "Installed Dependencies and ASP.NET Core Runtime"
 
 msg_info "Installing Technitium DNS"
 $STD bash <(curl -fsSL https://download.technitium.com/dns/install.sh)


### PR DESCRIPTION
The script was installing the Debian 11 version of the Microsoft packages repo on Debian 12, which isn't officially supported. Additionally, installing `libmsquic` allows Technitium DNS to serve DNS-over-QUIC, but this fails if the Debian 11 repo is used on Debian 12 (because it wants to install libssl-1.1, which is EOL and removed from Debian 12).

This PR fixes this issue by changing the version of the MS repo that's installed from 11 to 12. Additionally, this installs `libmsquic`, because you really might as well have that feature. Lastly, I condensed the `apt-get install` commands into one command after installing the MS repo, which will make the script run more quickly. 

Thanks for the useful scripts!

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Please include a summary of the change and/or which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
