### PR TITLE
The `b` of `bash` was missing in misc/build.func

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -564,7 +564,7 @@ EOF
   msg_ok "Started LXC Container"
   if [ "$var_os" == "alpine" ]; then
     sleep 2
-    pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
+    pct exec "$CTID" -- bash -c "apk add bash >/dev/null"
   fi
   lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/install/$var_install.sh)" || exit
 


### PR DESCRIPTION
There was a typo : the `b` of `bash` was missing.

It caused the following error : 
```
[ERROR] in line 567: exit code 1: while executing command pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
```