### PR TITLE
Rhasspy Voice Assistant

### DIFF
--- a/ct/rhasspy.sh
+++ b/ct/rhasspy.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2023 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+# Print Rhasspy
+cat <<"EOF"
+    ____  __                               
+   / __ \/ /_  ____ _______________  __  __
+  / /_/ / __ \/ __ `/ ___/ ___/ __ \/ / / /
+ / _, _/ / / / /_/ (__  |__  ) /_/ / /_/ / 
+/_/ |_/_/ /_/\__,_/____/____/ .___/\__, /  
+                           /_/    /____/ 
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Rhasspy"
+var_disk="16"
+var_cpu="2"
+var_ram="2048"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="0"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+    if [[ ! -d /var/lib/docker/volumes/rhasspy_profiles/_data ]]; then
+        msg_error "No ${APP} Installation Found!"
+        exit
+    fi
+    UPD=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "UPDATE" --radiolist --cancel-button Exit-Script "Spacebar = Select" 11 58 4 \
+     "1" "Update ALL Containers" ON \
+     "2" "Remove ALL Unused Images" OFF \
+    3>&1 1>&2 2>&3)
+    header_info
+
+    if [ "$UPD" == "1" ]; then
+    msg_info "Updating All Containers"
+    CONTAINER_LIST="${1:-$(docker ps -q)}"
+    for container in ${CONTAINER_LIST}; do
+      CONTAINER_IMAGE="$(docker inspect --format "{{.Config.Image}}" --type container ${container})"
+      RUNNING_IMAGE="$(docker inspect --format "{{.Image}}" --type container "${container}")"
+      docker pull "${CONTAINER_IMAGE}"
+      LATEST_IMAGE="$(docker inspect --format "{{.Id}}" --type image "${CONTAINER_IMAGE}")"
+      if [[ "${RUNNING_IMAGE}" != "${LATEST_IMAGE}" ]]; then
+        echo "Updating ${container} image ${CONTAINER_IMAGE}"
+        DOCKER_COMMAND="$(runlike "${container}")"
+        docker rm --force "${container}"
+        eval ${DOCKER_COMMAND}
+      fi
+    done
+    msg_ok "Updated All Containers"
+    exit
+  fi
+  if [ "$UPD" == "2" ]; then
+    msg_info "Removing ALL Unused Images"
+    docker image prune -af
+    msg_ok "Removed ALL Unused Images"
+    exit
+  fi
+
+
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+            ${BL}http://${IP}:12101${CL}\n"
+    

--- a/install/rhasspy-install.sh
+++ b/install/rhasspy-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2023 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl
+$STD apt-get install -y sudo
+$STD apt-get install -y mc
+msg_ok "Installed Dependencies"
+
+msg_info "Updating Python"
+$STD apt-get install -y \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv
+msg_ok "Updated Python"
+
+get_latest_release() {
+  curl -sL https://api.github.com/repos/$1/releases/latest | grep '"tag_name":' | cut -d'"' -f4
+}
+
+DOCKER_LATEST_VERSION=$(get_latest_release "moby/moby")
+RHASSPY_LATEST_VERSION=$(get_latest_release "rhasspy/rhasspy")
+
+msg_info "Installing Docker $DOCKER_LATEST_VERSION"
+DOCKER_CONFIG_PATH='/etc/docker/daemon.json'
+mkdir -p $(dirname $DOCKER_CONFIG_PATH)
+$STD sh <(curl -sSL https://get.docker.com)
+msg_ok "Installed Docker $DOCKER_LATEST_VERSION"
+
+msg_info "Pulling Rhasspy $RHASSPY_LATEST_VERSION Image"
+$STD docker pull rhasspy/rhasspy:latest
+msg_ok "Pulled Rhasspy $RHASSPY_LATEST_VERSION Image"
+
+msg_info "Installing Rhasspy"
+$STD docker volume create rhasspy_profiles
+$STD docker run -d \
+    -p 12101:12101 \
+    --name=rhasspy \
+    --restart=always \
+    -v "rhasspy_profiles:/profiles" \
+    -v "/etc/localtime:/etc/localtime:ro" \
+    rhasspy/rhasspy:latest \
+    --user-profiles /profiles \
+    --profile en
+mkdir /root/rhasspy_profiles
+msg_ok "Installed Rhasspy"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get autoremove
+$STD apt-get autoclean
+msg_ok "Cleaned"


### PR DESCRIPTION
## Description
[Rhasspy documentation](https://rhasspy.readthedocs.io/en/latest/)

Adds the option to install Rhasspy as an LXC container. Rhasspy runs within a Docker container inside the LXC, similar to how the Home Assistant LXC install is setup and follows their [Docker install documentation](https://rhasspy.readthedocs.io/en/latest/installation/#docker). 

This Rhasspy LXC container is meant to serve as a "base station" as demonstrated [here ](https://rhasspy.readthedocs.io/en/latest/tutorials/#server-with-satellites) in their documentation. This means it does not require sound devices to be passed into the Docker container. There may be some interest in allowing for sound devices to be passed through but I'm pretty novice with Proxmox so I wouldn't know where to begin with that.

I'm not 100% certain on all the default  values. The documentation recommends 32gb of disk but I think that is if you want to run every single service that Rhasspy provides, which shouldn't be the case with using this as a base station.

Resolves discussion item #1015 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix 
- [ ] New feature 
- [x] New Script
- [x] This change requires a documentation update (I guess, not sure with new scripts)