### PR TITLE
Updated address of cloud img file - ubuntu-vm.sh

### DIFF
--- a/vm/ubuntu-vm.sh
+++ b/vm/ubuntu-vm.sh
@@ -370,7 +370,7 @@ fi
 msg_ok "Using ${CL}${BL}$STORAGE${CL} ${GN}for Storage Location."
 msg_ok "Virtual Machine ID is ${CL}${BL}$VMID${CL}."
 msg_info "Retrieving the URL for the Ubuntu 22.04 Disk Image"
-URL=https://cloud-images.ubuntu.com/jammy/20231027/jammy-server-cloudimg-amd64.img
+URL=https://cloud-images.ubuntu.com/jammy/20231207/jammy-server-cloudimg-amd64.img
 sleep 2
 msg_ok "${CL}${BL}${URL}${CL}"
 wget -q --show-progress $URL


### PR DESCRIPTION
[ERROR] in line 376: exit code 8: while executing command wget -q --show-progress $URL
wget fails because the address doesn't exist anymore


The new one is '20231207'
https://cloud-images.ubuntu.com/jammy/20231207/jammy-server-cloudimg-amd64.img

The old one was '20231027'
https://cloud-images.ubuntu.com/jammy/20231027/jammy-server-cloudimg-amd64.img


## Type of change
- [ ] Bug fix 

