### PR TITLE
Update uptimekuma-install.sh: Install npm

### DIFF
--- a/install/uptimekuma-install.sh
+++ b/install/uptimekuma-install.sh
@@ -33,6 +33,10 @@ $STD apt-get update
 $STD apt-get install -y nodejs
 msg_ok "Installed Node.js"
 
+msg_info "Installing npm"
+$STD apt-get install -y npm
+msg_ok "Installed npm"
+
 msg_info "Installing Uptime Kuma"
 $STD git clone https://github.com/louislam/uptime-kuma.git
 mv uptime-kuma /opt/uptime-kuma


### PR DESCRIPTION
The script currently fails running "npm run setup", since npm is not installed. This patch adds npm installation.

Tested by running the script manually on an LXC container.

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

The script fails on debian 12 with this error:

```
 - Installing Uptime Kuma...+ git clone https://github.com/louislam/uptime-kuma.git
Cloning into 'uptime-kuma'...
remote: Enumerating objects: 29194, done.
remote: Counting objects: 100% (6885/6885), done.
remote: Compressing objects: 100% (316/316), done.
remote: Total 29194 (delta 6702), reused 6578 (delta 6569), pack-reused 22309
Receiving objects: 100% (29194/29194), 22.05 MiB | 51.66 MiB/s, done.
Resolving deltas: 100% (22264/22264), done.
+ mv uptime-kuma /opt/uptime-kuma
+ cd /opt/uptime-kuma
+ npm run setup
bash: line 40: npm: command not found
++ error_handler 40 '$STD npm run setup'
++ local exit_code=127
++ local line_number=40
++ local 'command=$STD npm run setup'
++ local 'error_message=\033[01;31m[ERROR]\033[m in line \033[01;31m40\033[m: exit code \033[01;31m127\033[m: while executing command \033[33m$STD npm run setup\033[m'
++ echo -e '\n\033[01;31m[ERROR]\033[m in line \033[01;31m40\033[m: exit code \033[01;31m127\033[m: while executing command \033[33m$STD npm run setup\033[m'

[ERROR] in line 40: exit code 127: while executing command $STD npm run setup
```

Looks like debian12 does not package npm alongside nodejs by default. The patch adds an explicit npm install after nodejs.

Fixes # (issue)

I did not create an issue for this beforehand

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 