### PR TITLE
portainer not available on port 9000

### DIFF
--- a/ct/homeassistant.sh
+++ b/ct/homeassistant.sh
@@ -136,4 +136,4 @@ msg_ok "Completed Successfully!\n"
 echo -e "${APP} should be reachable by going to the following URL.
          ${BL}http://${IP}:8123${CL}
 Portainer should be reachable by going to the following URL.
-         ${BL}http://${IP}:9000${CL}\n"
+         ${BL}https://${IP}:9443${CL}\n"


### PR DESCRIPTION
## Description

Please include a summary of the change and/or which issue is fixed. 
Portainer was not available on port 9000 as specificed in the comment after installing home assistant lxc edition.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
