### PR TITLE
Update paperless-ngx.sh

### DIFF
--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -81,8 +81,6 @@ function update_script() {
     cp -r /opt/paperless/paperless.conf paperless-ngx/
     cp -r paperless-ngx/* /opt/paperless/
     cd /opt/paperless
-    sed -i 's/scipy==1.8.1/scipy==1.10.1/g' requirements.txt
-    sed -i -e 's|-e git+https://github.com/paperless-ngx/django-q.git|git+https://github.com/paperless-ngx/django-q.git|' /opt/paperless/requirements.txt
     pip install -r requirements.txt &>/dev/null
     cd /opt/paperless/src
     /usr/bin/python3 manage.py migrate &>/dev/null


### PR DESCRIPTION
2 lines not needed anymore
scipy is version 1.11.4 and paperless is working fine with it