### PR TITLE
WIP Bump node version to 20.11.x for NPM

### DIFF
--- a/install/nginxproxymanager-install.sh
+++ b/install/nginxproxymanager-install.sh
@@ -54,10 +54,10 @@ $STD apt-get -y install openresty
 msg_ok "Installed Openresty"
 
 msg_info "Installing Node.js"
-$STD bash <(curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh)
+$STD bash <(curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh)
 source ~/.bashrc
-$STD nvm install 16.20.1
-ln -sf /root/.nvm/versions/node/v16.20.1/bin/node /usr/bin/node
+$STD nvm install 20.11.0
+ln -sf /root/.nvm/versions/node/v20.11.0/bin/node /usr/bin/node
 msg_ok "Installed Node.js"
 
 msg_info "Installing Yarn"


### PR DESCRIPTION
## Description

Version bump of node because the latest version of sass-loader expects at least node v18.x, this should solve the problem for new installations of Nginx Proxy Manager. Nowadays LTS v20.x is also more the standard for Node.

Fixes #2362

## Type of change

Please delete options that are not relevant.

- [X] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
