### PR TITLE
Add script for redis

### DIFF
--- a/ct/redis.sh
+++ b/ct/redis.sh
@@ -8,8 +8,7 @@ source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build
 function header_info {
 clear
 cat <<"EOF"
-
-   ____           ___     
+    ____           ___     
    / __ \___  ____/ (_)____
   / /_/ / _ \/ __  / / ___/
  / _, _/  __/ /_/ / (__  ) 

--- a/ct/redis.sh
+++ b/ct/redis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/madhur/Proxmox/redis/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT
@@ -13,7 +13,6 @@ cat <<"EOF"
   / /_/ / _ \/ __  / / ___/
  / _, _/  __/ /_/ / (__  ) 
 /_/ |_|\___/\__,_/_/____/  
-                           
 
 EOF
 }
@@ -56,7 +55,7 @@ function default_settings() {
 
 function update_script() {
 header_info
-if [[ ! -f /etc/systemd/system/redis.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+if [[ ! -f /lib/systemd/system/redis-server.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
 msg_error "There is currently no update path available."
 exit
 }

--- a/ct/redis.sh
+++ b/ct/redis.sh
@@ -8,7 +8,8 @@ source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build
 function header_info {
 clear
 cat <<"EOF"
-  ____           ___     
+
+   ____           ___     
    / __ \___  ____/ (_)____
   / /_/ / _ \/ __  / / ___/
  / _, _/  __/ /_/ / (__  ) 

--- a/ct/redis.sh
+++ b/ct/redis.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/madhur/Proxmox/redis/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+  ____           ___     
+   / __ \___  ____/ (_)____
+  / /_/ / _ \/ __  / / ___/
+ / _, _/  __/ /_/ / (__  ) 
+/_/ |_|\___/\__,_/_/____/  
+                           
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Redis"
+var_disk="4"
+var_cpu="1"
+var_ram="1024"
+var_os="debian"
+var_version="12"
+VERBOSE="yes"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -f /etc/systemd/system/redis.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_error "There is currently no update path available."
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"

--- a/install/redis-install.sh
+++ b/install/redis-install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl
+$STD apt-get install -y sudo
+$STD apt-get install -y mc
+$STD apt-get install -y apt-transport-https
+$STD apt-get install -y gnupg
+$STD apt-get install -y lsb-release
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Redis"
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+$STD apt-get update
+$STD apt-get install -y redis
+systemctl enable -q --now redis.service
+msg_ok "Installed Redis"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get autoremove
+$STD apt-get autoclean
+msg_ok "Cleaned"

--- a/install/redis-install.sh
+++ b/install/redis-install.sh
@@ -19,11 +19,12 @@ $STD apt-get install -y sudo
 $STD apt-get install -y mc
 $STD apt-get install -y apt-transport-https
 $STD apt-get install -y gnupg
+$STD apt-get install -y lsb-release
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Redis"
 curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(grep '^VERSION_CODENAME=' /etc/os-release | cut -d'=' -f2) main" | sudo tee /etc/apt/sources.list.d/redis.list
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 $STD apt-get update
 $STD apt-get install -y redis
 sed -i 's/^bind .*/bind 0.0.0.0/' /etc/redis/redis.conf

--- a/install/redis-install.sh
+++ b/install/redis-install.sh
@@ -27,7 +27,9 @@ curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyr
 echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 $STD apt-get update
 $STD apt-get install -y redis
-systemctl enable -q --now redis.service
+sed -i 's/^bind .*/bind 0.0.0.0/' /etc/redis/redis.conf
+systemctl enable -q redis-server.service
+systemctl restart -q redis-server.service
 msg_ok "Installed Redis"
 
 motd_ssh

--- a/install/redis-install.sh
+++ b/install/redis-install.sh
@@ -19,17 +19,15 @@ $STD apt-get install -y sudo
 $STD apt-get install -y mc
 $STD apt-get install -y apt-transport-https
 $STD apt-get install -y gnupg
-$STD apt-get install -y lsb-release
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Redis"
 curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(grep '^VERSION_CODENAME=' /etc/os-release | cut -d'=' -f2) main" | sudo tee /etc/apt/sources.list.d/redis.list
 $STD apt-get update
 $STD apt-get install -y redis
 sed -i 's/^bind .*/bind 0.0.0.0/' /etc/redis/redis.conf
-systemctl enable -q redis-server.service
-systemctl restart -q redis-server.service
+systemctl enable -q --now redis-server.service
 msg_ok "Installed Redis"
 
 motd_ssh

--- a/misc/build.func
+++ b/misc/build.func
@@ -579,7 +579,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/madhur/Proxmox/redis/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/install/$var_install.sh)" || exit
 
 }
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -579,7 +579,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/madhur/Proxmox/redis/install/$var_install.sh)" || exit
 
 }
 


### PR DESCRIPTION
Adds the script for [Redis](https://github.com/redis/redis)

## Description

Redis is used as a caching store for most distributed systems.  Having redis as a LXC will allow engineers to have Redis hosted in Proxmox rather than running on their own workstations.

## Type of change

Please delete options that are not relevant.

- [x] New Script

