### PR TITLE
Update jellyfin-install.sh

### DIFF
--- a/install/jellyfin-install.sh
+++ b/install/jellyfin-install.sh
@@ -31,6 +31,7 @@ if [[ "$CTTYPE" == "0" ]]; then
   $STD apt-get install -y intel-opencl-icd
   fi
   chgrp video /dev/dri
+  chgrp render /dev/dri/renderD128
   chmod 755 /dev/dri
   chmod 660 /dev/dri/*
   $STD adduser $(id -u -n) video


### PR DESCRIPTION
Render group keeps getting assigned to random groups instead of render for HW acceleration. Using a bash script in systemd corrects it. Wasn't sure if adding the chgrp in your install.sh would prevent the need for the bash script.

#! /bin/bash
chgrp render /dev/dri/renderD128

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Please include a summary of the change and/or which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix 

