### PR TITLE
Update changedetection.sh - playwright API changed and its possible the installed version was still the older version

### DIFF
--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -57,6 +57,8 @@ header_info
 if [[ ! -f /etc/systemd/system/changedetection.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
 msg_info "Updating ${APP} LXC"
 pip3 install changedetection.io --upgrade &>/dev/null
+# https://github.com/dgtlmoon/changedetection.io/blob/d31a45d49a3d50aff4c103aee47f75c598ca3ad4/Dockerfile#L28
+pip3 install playwright~=1.40 --upgrade &>/dev/null
 msg_ok "Updated Successfully"
 exit
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and/or which issue is fixed. 

Fixes # (issue)

https://github.com/tteck/Proxmox/issues/2391

`Error playwright._impl._errors` after upgrade, the API in playwright changed (we in changedetection.io started using a different naming convention according to the later playwright versions)

But its possible the installed version in proxmox was still old

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
