### PR TITLE
Added 'retry' option to the internet check.

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -78,21 +78,50 @@ setting_up_container() {
 network_check() {
   set +e
   trap - ERR
-  if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then msg_ok "Internet Connected"; else
-    msg_error "Internet NOT Connected"
-    read -r -p "Would you like to continue anyway? <y/N> " prompt
-    if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
-      echo -e " ⚠️  ${RD}Expect Issues Without Internet${CL}"
+
+  while true; do
+    if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then
+      msg_ok "Internet Connected"
+      break
     else
-      echo -e " 🖧  Check Network Settings"
-      exit 1
+      msg_error "Internet NOT Connected"
+      echo "Choose an option:"
+      echo "1) Continue without internet"
+      echo "2) Retest for internet connection"
+      echo "3) Abort"
+      read -r -p "Enter your choice (1/2/3): " choice
+
+      case $choice in
+        1)
+          echo -e " ⚠️  ${RD}Expect Issues Without Internet${CL}"
+          break
+          ;;
+        2)
+          echo "Retesting internet connection..."
+          continue
+          ;;
+        3)
+          echo -e " 🖧  Check Network Settings"
+          exit 1
+          ;;
+        *)
+          echo "Invalid option. Please enter 1, 2, or 3."
+          ;;
+      esac
     fi
-  fi
+  done
+
   RESOLVEDIP=$(getent hosts github.com | awk '{ print $1 }')
-  if [[ -z "$RESOLVEDIP" ]]; then msg_error "DNS Lookup Failure"; else msg_ok "DNS Resolved github.com to ${BL}$RESOLVEDIP${CL}"; fi
+  if [[ -z "$RESOLVEDIP" ]]; then
+    msg_error "DNS Lookup Failure"
+  else
+    msg_ok "DNS Resolved github.com to ${BL}$RESOLVEDIP${CL}"
+  fi
+
   set -e
   trap 'error_handler $LINENO "$BASH_COMMAND"' ERR
 }
+
 
 update_os() {
   msg_info "Updating Container OS"

--- a/misc/install.func
+++ b/misc/install.func
@@ -112,21 +112,50 @@ setting_up_container() {
 network_check() {
   set +e
   trap - ERR
-  if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then msg_ok "Internet Connected"; else
-    msg_error "Internet NOT Connected"
-    read -r -p "Would you like to continue anyway? <y/N> " prompt
-    if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
-      echo -e " ⚠️  ${RD}Expect Issues Without Internet${CL}"
+
+  while true; do
+    if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then
+      msg_ok "Internet Connected"
+      break
     else
-      echo -e " 🖧  Check Network Settings"
-      exit 1
+      msg_error "Internet NOT Connected"
+      echo "Choose an option:"
+      echo "1) Continue without internet"
+      echo "2) Retest for internet connection"
+      echo "3) Abort"
+      read -r -p "Enter your choice (1/2/3): " choice
+
+      case $choice in
+        1)
+          echo -e " ⚠️  ${RD}Expect Issues Without Internet${CL}"
+          break
+          ;;
+        2)
+          echo "Retesting internet connection..."
+          continue
+          ;;
+        3)
+          echo -e " 🖧  Check Network Settings"
+          exit 1
+          ;;
+        *)
+          echo "Invalid option. Please enter 1, 2, or 3."
+          ;;
+      esac
     fi
-  fi
+  done
+
   RESOLVEDIP=$(getent hosts github.com | awk '{ print $1 }')
-  if [[ -z "$RESOLVEDIP" ]]; then msg_error "DNS Lookup Failure"; else msg_ok "DNS Resolved github.com to ${BL}$RESOLVEDIP${CL}"; fi
+  if [[ -z "$RESOLVEDIP" ]]; then
+    msg_error "DNS Lookup Failure"
+  else
+    msg_ok "DNS Resolved github.com to ${BL}$RESOLVEDIP${CL}"
+  fi
+
   set -e
   trap 'error_handler $LINENO "$BASH_COMMAND"' ERR
 }
+
 
 # This function updates the Container OS by running apt-get update and upgrade
 update_os() {


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

I have modified the 'network_check' function that appears in both install.func and alpine-install.func.

### Current behaviour

If no internet connection is detected, the script asks the user if they would like to continue without an internet connection. If the user answers 'yes', then the script continues. If the user answers 'no', the install is aborted. 

### The issue

At present, there is no option to retry the connection check. If the user is able to resolve the internet connection issue, then retrying the install will require the user to abort the install. Once the user believes the connection issue is resolved, they can then restart the install script but they will need to set all the installation settings all over again. Internet connection issues can often be quickly and easily resolved. If the function gave the user an option to retry the internet connection check, the user could attempt to resolve their connection issues and then tell the script to retry the connection check, which will continue with the rest of the script if the connection is successful.  

### Updated behaviour

A connection check failure will have the script return a prompt giving the options:
- '1' to continue without internet (same behaviour as answering 'yes' to existing function)
- '2' to retry the internet test
- '3' to abort the script. (same behaviour as answering 'no' to existing function)


## Type of change

- [x] Bug fix 
- [x] New feature 
