### PR TITLE
Update esphome-install.sh

### DIFF
--- a/install/esphome-install.sh
+++ b/install/esphome-install.sh
@@ -30,7 +30,7 @@ msg_ok "Updated Python3"
 
 msg_info "Installing ESPHome"
 mkdir /root/config
-$STD pip install esphome tornado esptool
+$STD pip install --break-system-packages esphome tornado esptool
 msg_ok "Installed ESPHome"
 
 msg_info "Creating Service"


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

bare pip install gives "error: externally-managed-environment" on python 3.11+

Fixes # (issue)

added "--break-system-packages" option to the pip

