### PR TITLE
Adding the "tools" directory to the backup before updating homer

### DIFF
--- a/ct/homer.sh
+++ b/ct/homer.sh
@@ -62,7 +62,8 @@ msg_ok "Stopped ${APP}"
 msg_info "Backing up config.yml"
 cd ~
 cp -R /opt/homer/assets/config.yml config.yml
-msg_ok "Backed up config.yml"
+cp -R /opt/homer/assets/tools tools
+msg_ok "Backed up config.yml and tools directory"
 
 msg_info "Updating ${APP}"
 rm -rf /opt/homer/*
@@ -73,10 +74,11 @@ msg_ok "Updated ${APP}"
 msg_info "Restoring conf.yml"
 cd ~
 cp -R config.yml /opt/homer/assets
-msg_ok "Restored conf.yml"
+cp -R tools /opt/homer/assets
+msg_ok "Restored config.yml and tools directory"
 
 msg_info "Cleaning"
-rm -rf config.yml /opt/homer/homer.zip
+rm -rf config.yml tools /opt/homer/homer.zip
 msg_ok "Cleaned"
 
 msg_info "Starting ${APP}"


### PR DESCRIPTION
## Description

Before, "update" script removed the whole "homer" directory including icons that were placed in the "tools" directory. 
This change includes the "tools" directory into the backup and restore actions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
