### PR TITLE
fix(n8n): add missing installation dependency

### DIFF
--- a/install/n8n-install.sh
+++ b/install/n8n-install.sh
@@ -33,6 +33,7 @@ $STD apt-get install -y nodejs
 msg_ok "Installed Node.js"
 
 msg_info "Installing n8n (Patience)"
+$STD npm install --global patch-package
 $STD npm install --global n8n
 msg_ok "Installed n8n"
 


### PR DESCRIPTION
## Description

Install `patch-package` depndency before running `n8n` installation.

Fixes https://github.com/tteck/Proxmox/issues/2465

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
