### PR TITLE
Add curl and sudo

### DIFF
--- a/misc/code-server.sh
+++ b/misc/code-server.sh
@@ -68,7 +68,7 @@ function msg_ok() {
 
 msg_info "Installing Dependencies"
 apt-get update &>/dev/null
-apt-get install -y git &>/dev/null
+apt-get install -y git curl sudo &>/dev/null
 msg_ok "Installed Dependencies"
 
 VERSION=$(curl -s https://api.github.com/repos/coder/code-server/releases/latest |


### PR DESCRIPTION
## Description

Packages “curl” and “sudo” are not default packages to debian-12-standard_12.2-1 container template which causes script to fail. Container was created using GUI. These packages appear to have been removed in #2297.

To my knowledge, debian-12-standard_12.2-1 is the latest available template.

```
root@pve:~# pveam update
update successful
root@pve:~# pveam available | grep "debian"
system          debian-11-standard_11.7-1_amd64.tar.zst
system          debian-12-standard_12.2-1_amd64.tar.zst
```


## Error
>  ✓ Installed Dependencies
> bash: line 76: curl: command not found
> ‼ ERROR 1@76 Unknown failure occured.
> ‼ ERROR 1@76 Unknown failure occured.

Related #2297 (issue)

## Type of change

Added curl and sudo packages referenced later on in script. This should have no effect on other distro templates that may include these packages by default.

What are your thoughts?

- [x] Bug fix 
- [ ] This change requires a documentation update
