### PR TITLE
Update photoprism-install.sh

### DIFF
--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -25,6 +25,7 @@ $STD apt-get install -y libjpeg-dev
 $STD apt-get install -y libtiff-dev
 $STD apt-get install -y imagemagick
 $STD apt-get install -y darktable
+$STD apt-get install -y rawtherapee
 
 msg_ok "Installed Dependencies"
 


### PR DESCRIPTION
add rawtherapee dependency to enable raw image conversion

## Description

In order to use the RAW image conversion using RawTherapee, this dependency is needed, otherwise the feature in `Settiongs -> Advanced` is not toggleable (it remains checked because it can't find the binary):
![image](https://github.com/tteck/Proxmox/assets/4378253/e6f05382-6447-448a-96de-16e363a02be1)

## Type of change

- [x] Bug fix 
- [x] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
