### PR TITLE
Update photoprism-install.sh

### DIFF
--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -27,6 +27,8 @@ $STD apt-get install -y imagemagick
 $STD apt-get install -y darktable
 $STD apt-get install -y rawtherapee
 
+echo 'export PATH=/usr/local:$PATH' >>~/.bashrc
+export PATH=/usr/local:$PATH
 msg_ok "Installed Dependencies"
 
 msg_info "Installing PhotoPrism (Patience)"


### PR DESCRIPTION
## Description

For some reason it seems as though the binaries as part of `libheif1` install not to `/usr/local/bin` but to `/usr/local` and so were not on the path, therefore the default value of photoprism's `--heifconvert-bin` / `$PHOTOPRISM_HEIFCONVERT_BIN` (`heif-convert`) would not be resolved

![image](https://github.com/tteck/Proxmox/assets/4378253/07a67d3d-d938-45dc-8de3-2dc6c8b0b53b)


## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] New Script
- [ ] This change requires a documentation update
