### PR TITLE
Add support for postgresql DB and fail2ban in vaultwarden

### DIFF
--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -139,7 +139,7 @@ build_container
 description
 
 msg_info "Setting Container to Normal Resources"
-pct set $CTID -memory 512
+pct set $CTID -memory 256
 pct set $CTID -cores 1
 msg_ok "Set Container to Normal Resources"
 msg_ok "Completed Successfully!\n"

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -84,10 +84,8 @@ curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/$WEBV
 tar -xzf bw_web_$WEBVAULT.tar.gz -C /opt/vaultwarden/
 msg_ok "Downloaded Web-Vault ${WEBVAULT}"
 
-#debugging...
-cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1 > testy
-
-$STD admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
+#admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
+admintoken=$(generate_token 50)
 
 #Local server IP
 $STD vw_ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
@@ -112,7 +110,8 @@ if [ "$DB_ENGINE" == "postgresql" ]; then
 
   ### Configure PostgreSQL DB
   # Random password
-  postgresql_pwd=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 24 | head -n 1)
+  #postgresql_pwd=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 24 | head -n 1)
+  postgresql_pwd=$(generate_token)
   sudo -u postgres psql -c "CREATE DATABASE vaultwarden;"
   sudo -u postgres psql -c "CREATE USER vaultwarden WITH ENCRYPTED PASSWORD '${postgresql_pwd}';"
   sudo -u postgres psql -c "GRANT all privileges ON database vaultwarden TO vaultwarden;"

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -88,7 +88,9 @@ msg_ok "Downloaded Web-Vault ${WEBVAULT}"
 admintoken=$(generate_token 50)
 
 #Local server IP
-$STD vw_ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+vw_ip4=$(hostname -I | awk '{print $1}')
+#vw_ip4=$(ip a s dev eth0 | awk '/inet / {print $2}' | cut -d/ -f1)
+#$STD vw_ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
 #echo "Local IP:$ip4"
 
 cat <<EOF >/opt/vaultwarden/.env

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -85,7 +85,7 @@ tar -xzf bw_web_$WEBVAULT.tar.gz -C /opt/vaultwarden/
 msg_ok "Downloaded Web-Vault ${WEBVAULT}"
 
 #admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
-admintoken=$(generate_token 50)
+admintoken=$(generate_token)
 
 #Local server IP
 vw_ip4=$(hostname -I | awk '{print $1}')
@@ -219,6 +219,7 @@ maxretry = 5
 bantime = 14400
 findtime = 14400" > $vaultwardenfail2banadminjail
 
+  systemctl daemon-reload
   $STD systemctl restart fail2ban
   msg_info "Configured fail2ban"
 fi

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -220,7 +220,9 @@ findtime = 14400" > $vaultwardenfail2banadminjail
 
   #In case of debian os, need to explicitly set the backend for fail2ban
   #see https://github.com/fail2ban/fail2ban/issues/3292
-  if [ "$var_os" == "debian" ]; then
+  os=$(less /etc/os-release | grep "^ID=")
+  os="${os:3}"
+  if [ "$os" == "debian" ]; then
     echo "backend = systemd" >> /etc/fail2ban/jail.d/defaults-debian.conf
   fi
 

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -230,4 +230,6 @@ $STD apt-get autoremove
 $STD apt-get autoclean
 msg_ok "Cleaned"
 
-msg_info "Enter ${admintoken} to gain access to admin panel, please save this somewhere! Admin panel accessible at $vw_ip4:8000/admin"
+msg_info "Important! Save the following admin token:"
+msg_info "${admintoken}"
+msg_info "Admin panel accessible at $vw_ip4:8000/admin"

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -231,6 +231,6 @@ $STD apt-get autoremove
 $STD apt-get autoclean
 msg_ok "Cleaned"
 
-msg_info "Important! Save the following admin token:"
-msg_info "${admintoken}"
+msg_info "Important! Save the following admin token:\n"
+msg_info "${admintoken}\n"
 msg_info "Admin panel accessible at $vw_ip4:8000/admin"

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -118,6 +118,7 @@ if [ "$DB_ENGINE" == "postgresql" ]; then
   sudo -u postgres psql -c "CREATE DATABASE vaultwarden;"
   sudo -u postgres psql -c "CREATE USER vaultwarden WITH ENCRYPTED PASSWORD '${postgresql_pwd}';"
   sudo -u postgres psql -c "GRANT all privileges ON database vaultwarden TO vaultwarden;"
+  sudo -u postgres psql -c "GRANT all ON SCHEMA public TO vaultwarden;"
   #echo "Successfully setup PostgreSQL DB vaultwarden with user vaultwarden and password ${postgresql_pwd}"
 
   echo "DATABASE_URL=postgresql://vaultwarden:${postgresql_pwd}@localhost:5432/vaultwarden" >> /opt/vaultwarden/.env

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -193,7 +193,6 @@ enabled = true
 port = 80,443,8081
 filter = vaultwarden
 action = iptables-allports[name=vaultwarden]
-logpath = /var/log/vaultwarden/error.log
 maxretry = 3
 bantime = 14400
 findtime = 14400" > $vaultwardenfail2banjail
@@ -214,7 +213,6 @@ enabled = true
 port = 80,443
 filter = vaultwarden-admin
 action = iptables-allports[name=vaultwarden]
-logpath = /var/log/vaultwarden/error.log
 maxretry = 5
 bantime = 14400
 findtime = 14400" > $vaultwardenfail2banadminjail

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -218,6 +218,12 @@ maxretry = 5
 bantime = 14400
 findtime = 14400" > $vaultwardenfail2banadminjail
 
+  #In case of debian os, need to explicitly set the backend for fail2ban
+  #see https://github.com/fail2ban/fail2ban/issues/3292
+  if [ "$var_os" == "debian" ]; then
+    echo "backend = systemd" >> /etc/fail2ban/jail.d/defaults-debian.conf
+  fi
+
   systemctl daemon-reload
   $STD systemctl restart fail2ban
   msg_info "Configured fail2ban"
@@ -231,6 +237,6 @@ $STD apt-get autoremove
 $STD apt-get autoclean
 msg_ok "Cleaned"
 
-msg_info "Important! Save the following admin token:\n"
-msg_info "${admintoken}\n"
+msg_info "Important! Save the following admin token:"
+echo "${admintoken}"
 msg_info "Admin panel accessible at $vw_ip4:8000/admin"

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -86,6 +86,7 @@ msg_ok "Downloaded Web-Vault ${WEBVAULT}"
 
 #admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
 admintoken=$(generate_token)
+admintoken_hash=$(echo -n ${admintoken} | argon2 "$(openssl rand -base64 32)" -t 2 -m 16 -p 4 -l 64 -e)
 
 #Local server IP
 vw_ip4=$(hostname -I | awk '{print $1}')
@@ -94,7 +95,7 @@ vw_ip4=$(hostname -I | awk '{print $1}')
 #echo "Local IP:$ip4"
 
 cat <<EOF >/opt/vaultwarden/.env
-ADMIN_TOKEN=${admintoken}
+ADMIN_TOKEN=${admintoken_hash}
 ROCKET_ADDRESS=${vw_ip4}
 DATA_FOLDER=/opt/vaultwarden/data
 DATABASE_MAX_CONNS=10

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -29,7 +29,7 @@ fi
 done
 
 #Fail2ban option
-if (whiptail --backtitle "Proxmox VE Helper Scripts" --defaultyes --title "Fail2ban" --yesno "Configure fail2ban?" 10 58); then
+if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "Fail2ban" --yesno "Configure fail2ban?" 10 58); then
   ENABLE_F2B=1
 else
   ENABLE_F2B=0
@@ -84,7 +84,10 @@ curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/$WEBV
 tar -xzf bw_web_$WEBVAULT.tar.gz -C /opt/vaultwarden/
 msg_ok "Downloaded Web-Vault ${WEBVAULT}"
 
-admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
+#debugging...
+cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1 > testy
+
+$STD admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
 
 #Local server IP
 $STD vw_ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -13,6 +13,28 @@ setting_up_container
 network_check
 update_os
 
+#Select DB engine (Sqlite or PostgreSQL, will maybe add MySQL later)
+DB_ENGINE=""
+while [ -z "$DB_ENGINE" ]; do
+if DB_ENGINE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "VAULTWARDEN DATABASE" --radiolist "Choose Database" 10 58 2 \
+  "sqlite" "" OFF \
+  "postgresql" "" OFF \
+  3>&1 1>&2 2>&3); then
+  if [ -n "$DB_ENGINE" ]; then
+	echo -e "${DGN}Using Database Engine: ${BGN}$DB_ENGINE${CL}"
+  fi
+else
+  exit-script
+fi
+done
+
+#Fail2ban option
+if (whiptail --backtitle "Proxmox VE Helper Scripts" --defaultyes --title "Fail2ban" --yesno "Configure fail2ban?" 10 58); then
+  ENABLE_F2B=1
+else
+  ENABLE_F2B=0
+fi
+
 msg_info "Installing Dependencies"
 $STD apt-get update
 $STD apt-get -qqy install \
@@ -47,7 +69,8 @@ msg_ok "Installed Rust"
 msg_info "Building Vaultwarden ${VAULT} (Patience)"
 $STD git clone https://github.com/dani-garcia/vaultwarden
 cd vaultwarden
-$STD cargo build --features "sqlite,mysql,postgresql" --release
+#$STD cargo build --features "sqlite,mysql,postgresql" --release
+$STD cargo build --features "$DB_ENGINE" --release
 msg_ok "Built Vaultwarden ${VAULT}"
 
 $STD addgroup --system vaultwarden
@@ -57,18 +80,45 @@ mkdir -p /opt/vaultwarden/data
 cp target/release/vaultwarden /opt/vaultwarden/bin/
 
 msg_info "Downloading Web-Vault ${WEBVAULT}"
-$STD curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/$WEBVAULT/bw_web_$WEBVAULT.tar.gz
-$STD tar -xzf bw_web_$WEBVAULT.tar.gz -C /opt/vaultwarden/
+curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/$WEBVAULT/bw_web_$WEBVAULT.tar.gz
+tar -xzf bw_web_$WEBVAULT.tar.gz -C /opt/vaultwarden/
 msg_ok "Downloaded Web-Vault ${WEBVAULT}"
 
+admintoken=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 70 | head -n 1)
+
+#Local server IP
+$STD vw_ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+#echo "Local IP:$ip4"
+
 cat <<EOF >/opt/vaultwarden/.env
-ADMIN_TOKEN=''
-ROCKET_ADDRESS=0.0.0.0
+ADMIN_TOKEN=${admintoken}
+ROCKET_ADDRESS=${vw_ip4}
 DATA_FOLDER=/opt/vaultwarden/data
 DATABASE_MAX_CONNS=10
 WEB_VAULT_FOLDER=/opt/vaultwarden/web-vault
 WEB_VAULT_ENABLED=true
 EOF
+
+
+if [ "$DB_ENGINE" == "postgresql" ]; then
+  msg_info "Installing PostgreSQL"
+  #sudo apt install postgresql postgresql-contrib libpq-dev dirmngr git libssl-dev pkg-config build-essential curl wget apt-transport-https ca-certificates software-properties-common pwgen -y
+  $STD apt -qqy install postgresql postgresql-contrib
+  msg_ok "Installed PostgreSQL"
+  
+
+  ### Configure PostgreSQL DB
+  # Random password
+  postgresql_pwd=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 24 | head -n 1)
+  sudo -u postgres psql -c "CREATE DATABASE vaultwarden;"
+  sudo -u postgres psql -c "CREATE USER vaultwarden WITH ENCRYPTED PASSWORD '${postgresql_pwd}';"
+  sudo -u postgres psql -c "GRANT all privileges ON database vaultwarden TO vaultwarden;"
+  #echo "Successfully setup PostgreSQL DB vaultwarden with user vaultwarden and password ${postgresql_pwd}"
+
+  echo "DATABASE_URL=postgresql://vaultwarden:${postgresql_pwd}@localhost:5432/vaultwarden" >> /opt/vaultwarden/.env
+fi
+
+
 
 msg_info "Creating Service"
 chown -R vaultwarden:vaultwarden /opt/vaultwarden/
@@ -110,6 +160,65 @@ systemctl daemon-reload
 $STD systemctl enable --now vaultwarden.service
 msg_ok "Created Service"
 
+
+if [ "$ENABLE_F2B" == 1 ]; then
+  msg_info "Configuring fail2ban"
+
+  #####Fail2ban setup
+  $STD apt -qqy install fail2ban
+
+  #Create files
+  touch /etc/fail2ban/filter.d/vaultwarden.conf
+  touch /etc/fail2ban/jail.d/vaultwarden.local
+  touch /etc/fail2ban/filter.d/vaultwarden-admin.conf
+  touch /etc/fail2ban/jail.d/vaultwarden-admin.local
+
+  #Set vaultwarden fail2ban filter conf File
+  vaultwardenfail2banfilter="/etc/fail2ban/filter.d/vaultwarden.conf"
+  echo "[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^.*Username or password is incorrect\. Try again\. IP: <HOST>\. Username:.*$
+ignoreregex =" > $vaultwardenfail2banfilter
+
+  #Set vaultwarden fail2ban jail conf File
+  vaultwardenfail2banjail="/etc/fail2ban/jail.d/vaultwarden.local"
+  echo "[vaultwarden]
+enabled = true
+port = 80,443,8081
+filter = vaultwarden
+action = iptables-allports[name=vaultwarden]
+logpath = /var/log/vaultwarden/error.log
+maxretry = 3
+bantime = 14400
+findtime = 14400" > $vaultwardenfail2banjail
+
+  #Set vaultwarden fail2ban admin filter conf File
+  vaultwardenfail2banadminfilter="/etc/fail2ban/filter.d/vaultwarden-admin.conf"
+  echo "[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^.*Unauthorized Error: Invalid admin token\. IP: <HOST>.*$
+ignoreregex =" > $vaultwardenfail2banadminfilter
+
+  #Set vaultwarden fail2ban admin jail conf File
+  vaultwardenfail2banadminjail="/etc/fail2ban/jail.d/vaultwarden-admin.local"
+  echo "[vaultwarden-admin]
+enabled = true
+port = 80,443
+filter = vaultwarden-admin
+action = iptables-allports[name=vaultwarden]
+logpath = /var/log/vaultwarden/error.log
+maxretry = 5
+bantime = 14400
+findtime = 14400" > $vaultwardenfail2banadminjail
+
+  $STD systemctl restart fail2ban
+  msg_info "Configured fail2ban"
+fi
+
 motd_ssh
 customize
 
@@ -117,3 +226,5 @@ msg_info "Cleaning up"
 $STD apt-get autoremove
 $STD apt-get autoclean
 msg_ok "Cleaned"
+
+msg_info "Enter ${admintoken} to gain access to admin panel, please save this somewhere! Admin panel accessible at $vw_ip4:8000/admin"

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -118,7 +118,8 @@ if [ "$DB_ENGINE" == "postgresql" ]; then
   sudo -u postgres psql -c "CREATE DATABASE vaultwarden;"
   sudo -u postgres psql -c "CREATE USER vaultwarden WITH ENCRYPTED PASSWORD '${postgresql_pwd}';"
   sudo -u postgres psql -c "GRANT all privileges ON database vaultwarden TO vaultwarden;"
-  sudo -u postgres psql -c "GRANT all ON SCHEMA public TO vaultwarden;"
+  sudo -u postgres psql -c "GRANT USAGE ON SCHEMA public TO vaultwarden;"
+  sudo -u postgres psql -c "ALTER DATABASE vaultwarden OWNER TO vaultwarden;"
   #echo "Successfully setup PostgreSQL DB vaultwarden with user vaultwarden and password ${postgresql_pwd}"
 
   echo "DATABASE_URL=postgresql://vaultwarden:${postgresql_pwd}@localhost:5432/vaultwarden" >> /opt/vaultwarden/.env

--- a/misc/install.func
+++ b/misc/install.func
@@ -197,3 +197,17 @@ EOF
   echo "bash -c \"\$(wget -qLO - https://github.com/tteck/Proxmox/raw/main/ct/${app}.sh)\"" >/usr/bin/update
   chmod +x /usr/bin/update
 }
+
+# This function generates a token. The length of the token needs to be passed as the first parameter, otherwise defaults to 30
+generate_token() {
+  token_len=30
+  
+  #check if first parameter was passed and it's an integer
+  if [ $# -ge 1 ] && [ ! -z "$1" ] && [[ $1 =~ ^[-+]?[0-9]+$ ]]; then
+    token_len=$1
+  fi
+  
+  #For some reason, the /dev/urandom approach does not work inside an install script
+  #tr -dc A-Za-z0-9 </dev/urandom | head -c$token_len
+  openssl rand -base64 $token_len
+}

--- a/misc/install.func
+++ b/misc/install.func
@@ -209,5 +209,5 @@ generate_token() {
   
   #For some reason, the /dev/urandom approach does not work inside an install script
   #tr -dc A-Za-z0-9 </dev/urandom | head -c$token_len
-  openssl rand -base64 $token_len
+  openssl rand -hex $token_len
 }


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Added support for postgresql and fail2ban to vaultwarden. Both are optional and can be enabled/disabled during install script.
I also added a token generation function (pass length as first argument, otherwise defaults to 30), which is used to generate both the vaultwarden admin token and the password of the vaultwarden postgres user

## Type of change

- [x] New feature 

