### PR TITLE
Enable firewall option by defaults for all LXC

### DIFF
--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/agentdvr.sh
+++ b/ct/agentdvr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/alpine-docker.sh
+++ b/ct/alpine-docker.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/alpine-grafana.sh
+++ b/ct/alpine-grafana.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/alpine-nextcloud.sh
+++ b/ct/alpine-nextcloud.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/alpine-vaultwarden.sh
+++ b/ct/alpine-vaultwarden.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/alpine-zigbee2mqtt.sh
+++ b/ct/alpine-zigbee2mqtt.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/alpine.sh
+++ b/ct/alpine.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/apache-cassandra.sh
+++ b/ct/apache-cassandra.sh
@@ -48,6 +48,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/apache-couchdb.sh
+++ b/ct/apache-couchdb.sh
@@ -48,6 +48,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/apt-cacher-ng.sh
+++ b/ct/apt-cacher-ng.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/audiobookshelf.sh
+++ b/ct/audiobookshelf.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/autobrr.sh
+++ b/ct/autobrr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/blocky.sh
+++ b/ct/blocky.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/casaos.sh
+++ b/ct/casaos.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/channels.sh
+++ b/ct/channels.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/cloudflared.sh
+++ b/ct/cloudflared.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/commafeed.sh
+++ b/ct/commafeed.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/cronicle.sh
+++ b/ct/cronicle.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/daemonsync.sh
+++ b/ct/daemonsync.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/dashy.sh
+++ b/ct/dashy.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/debian.sh
+++ b/ct/debian.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/deconz.sh
+++ b/ct/deconz.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/deluge.sh
+++ b/ct/deluge.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/docker.sh
+++ b/ct/docker.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/dockge.sh
+++ b/ct/dockge.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/emby.sh
+++ b/ct/emby.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/emqx.sh
+++ b/ct/emqx.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/esphome.sh
+++ b/ct/esphome.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/fhem.sh
+++ b/ct/fhem.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/go2rtc.sh
+++ b/ct/go2rtc.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/gokapi.sh
+++ b/ct/gokapi.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/gotify.sh
+++ b/ct/gotify.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/grafana.sh
+++ b/ct/grafana.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/grocy.sh
+++ b/ct/grocy.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/heimdalldashboard.sh
+++ b/ct/heimdalldashboard.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/hivemq.sh
+++ b/ct/hivemq.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/homarr.sh
+++ b/ct/homarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/homeassistant-core.sh
+++ b/ct/homeassistant-core.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/homeassistant.sh
+++ b/ct/homeassistant.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/homebridge.sh
+++ b/ct/homebridge.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/homer.sh
+++ b/ct/homer.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/hyperhdr.sh
+++ b/ct/hyperhdr.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/hyperion.sh
+++ b/ct/hyperion.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/influxdb.sh
+++ b/ct/influxdb.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/iobroker.sh
+++ b/ct/iobroker.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/jackett.sh
+++ b/ct/jackett.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/k0s.sh
+++ b/ct/k0s.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/kavita.sh
+++ b/ct/kavita.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/keycloak.sh
+++ b/ct/keycloak.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/lidarr.sh
+++ b/ct/lidarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/mafl.sh
+++ b/ct/mafl.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/magicmirror.sh
+++ b/ct/magicmirror.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/mariadb.sh
+++ b/ct/mariadb.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/meshcentral.sh
+++ b/ct/meshcentral.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/motioneye.sh
+++ b/ct/motioneye.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/mqtt.sh
+++ b/ct/mqtt.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/n8n.sh
+++ b/ct/n8n.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/navidrome.sh
+++ b/ct/navidrome.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/nextcloudpi.sh
+++ b/ct/nextcloudpi.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/nocodb.sh
+++ b/ct/nocodb.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/node-red.sh
+++ b/ct/node-red.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/ntfy.sh
+++ b/ct/ntfy.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/octoprint.sh
+++ b/ct/octoprint.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/omada.sh
+++ b/ct/omada.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/ombi.sh
+++ b/ct/ombi.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/omv.sh
+++ b/ct/omv.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/openhab.sh
+++ b/ct/openhab.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/openobserve.sh
+++ b/ct/openobserve.sh
@@ -48,6 +48,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/overseerr.sh
+++ b/ct/overseerr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/owncast.sh
+++ b/ct/owncast.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/pairdrop.sh
+++ b/ct/pairdrop.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/pialert.sh
+++ b/ct/pialert.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/pihole.sh
+++ b/ct/pihole.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/pingvin.sh
+++ b/ct/pingvin.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/plex.sh
+++ b/ct/plex.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/podman-homeassistant.sh
+++ b/ct/podman-homeassistant.sh
@@ -50,6 +50,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/podman.sh
+++ b/ct/podman.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/postgresql.sh
+++ b/ct/postgresql.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/prometheus.sh
+++ b/ct/prometheus.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/prowlarr.sh
+++ b/ct/prowlarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/qbittorrent.sh
+++ b/ct/qbittorrent.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/radarr.sh
+++ b/ct/radarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/rdtclient.sh
+++ b/ct/rdtclient.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/readarr.sh
+++ b/ct/readarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/readeck.sh
+++ b/ct/readeck.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/redis.sh
+++ b/ct/redis.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/rockylinux.sh
+++ b/ct/rockylinux.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/rtsptoweb.sh
+++ b/ct/rtsptoweb.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/runtipi.sh
+++ b/ct/runtipi.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/sabnzbd.sh
+++ b/ct/sabnzbd.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/scrypted.sh
+++ b/ct/scrypted.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/sftpgo.sh
+++ b/ct/sftpgo.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/shinobi.sh
+++ b/ct/shinobi.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/sonarr.sh
+++ b/ct/sonarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/syncthing.sh
+++ b/ct/syncthing.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/tandoor.sh
+++ b/ct/tandoor.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/tasmoadmin.sh
+++ b/ct/tasmoadmin.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/tdarr.sh
+++ b/ct/tdarr.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/technitiumdns.sh
+++ b/ct/technitiumdns.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/transmission.sh
+++ b/ct/transmission.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/trilium.sh
+++ b/ct/trilium.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/ubuntu.sh
+++ b/ct/ubuntu.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/umbrel.sh
+++ b/ct/umbrel.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/unifi.sh
+++ b/ct/unifi.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/unmanic.sh
+++ b/ct/unmanic.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/uptimekuma.sh
+++ b/ct/uptimekuma.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/whisparr.sh
+++ b/ct/whisparr.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/whoogle.sh
+++ b/ct/whoogle.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/wikijs.sh
+++ b/ct/wikijs.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/wireguard.sh
+++ b/ct/wireguard.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/yunohost.sh
+++ b/ct/yunohost.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/zigbee2mqtt.sh
+++ b/ct/zigbee2mqtt.sh
@@ -47,6 +47,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/ct/zwave-js-ui.sh
+++ b/ct/zwave-js-ui.sh
@@ -46,6 +46,7 @@ function default_settings() {
   SD=""
   NS=""
   MAC=""
+  FW=1
   VLAN=""
   SSH="no"
   VERB="no"

--- a/misc/all-templates.sh
+++ b/misc/all-templates.sh
@@ -85,7 +85,7 @@ PCT_OPTIONS="
     -cores 2
     -memory 2048
     -password $PASS
-    -net0 name=eth0,bridge=vmbr0,ip=dhcp
+    -net0 name=eth0,bridge=vmbr0,firewall=1,ip=dhcp
     -unprivileged 1
   "
 DEFAULT_PCT_OPTIONS=(

--- a/misc/build.func
+++ b/misc/build.func
@@ -417,6 +417,13 @@ advanced_settings() {
   else
     exit-script
   fi
+  
+  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "Enable firewall" --yesno "Enable firewall?" 10 58); then
+    FW=1
+  else
+    FW=0
+  fi
+  echo -e "${DGN}Enable Firewall: ${BGN}$FW${CL}"
 
   if VLAN1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set a Vlan(leave blank for default)" 8 58 --title "VLAN" 3>&1 1>&2 2>&3); then
     if [ -z $VLAN1 ]; then
@@ -543,7 +550,7 @@ build_container() {
     -tags proxmox-helper-scripts
     $SD
     $NS
-    -net0 name=eth0,bridge=$BRG$MAC,ip=$NET$GATE$VLAN$MTU
+    -net0 name=eth0,bridge=$BRG$MAC,firewall=$FW,ip=$NET$GATE$VLAN$MTU
     -onboot 1
     -cores $CORE_COUNT
     -memory $RAM_SIZE

--- a/turnkey/turnkey.sh
+++ b/turnkey/turnkey.sh
@@ -106,7 +106,7 @@ PCT_OPTIONS="
     -cores 2
     -memory 2048
     -password $PASS
-    -net0 name=eth0,bridge=vmbr0,ip=dhcp
+    -net0 name=eth0,bridge=vmbr0,firewall=1,ip=dhcp
     -unprivileged 1
   "
 DEFAULT_PCT_OPTIONS=(


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

The default configuration when creating an LXC through the proxmox web interface has the network firewall option enabled. I made it the default for all LXC, but it can still be disabled through the advanced menu selection

## Type of change

Please delete options that are not relevant.

- [X] New feature
