### PR TITLE
Leave keyctl off by default as recommended

### DIFF
--- a/misc/all-templates.sh
+++ b/misc/all-templates.sh
@@ -77,8 +77,10 @@ TEMPLATE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "All Templat
 NAME=$(echo "$TEMPLATE" | grep -oE '^[^-]+-[^-]+')
 PASS="$(openssl rand -base64 8)"
 CTID=$(pvesh get /cluster/nextid)
+#Recommended default for unprivileged containers is to leave keyctl off
+#https://forum.proxmox.com/threads/how-does-keyctl-works-in-virtual-environments.116414/
 PCT_OPTIONS="
-    -features keyctl=1,nesting=1
+    -features nesting=1
     -hostname $NAME
     -tags proxmox-helper-scripts
     -onboot 0

--- a/misc/build.func
+++ b/misc/build.func
@@ -509,11 +509,14 @@ start() {
 build_container() {
 #  if [ "$VERB" == "yes" ]; then set -x; fi
 
-  if [ "$CT_TYPE" == "1" ]; then
-    FEATURES="keyctl=1,nesting=1"
-  else
-    FEATURES="nesting=1"
-  fi
+#Recommended default for unprivileged containers is to leave keyctl off
+#https://forum.proxmox.com/threads/how-does-keyctl-works-in-virtual-environments.116414/
+  FEATURES="nesting=1"
+#  if [ "$CT_TYPE" == "1" ]; then
+#    FEATURES="keyctl=1,nesting=1"
+#  else
+#    FEATURES="nesting=1"
+#  fi
 
 
   TEMP_DIR=$(mktemp -d)

--- a/turnkey/turnkey.sh
+++ b/turnkey/turnkey.sh
@@ -98,8 +98,10 @@ turnkey=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "TurnKey LXCs
 # Setup script environment
 PASS="$(openssl rand -base64 8)"
 CTID=$(pvesh get /cluster/nextid)
+#Recommended default for unprivileged containers is to leave keyctl off
+#https://forum.proxmox.com/threads/how-does-keyctl-works-in-virtual-environments.116414/
 PCT_OPTIONS="
-    -features keyctl=1,nesting=1
+    -features nesting=1
     -hostname turnkey-${turnkey}
     -tags proxmox-helper-scripts
     -onboot 1


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Default config when building a new LXC with proxmox web interface has `keyctl` disabled. Also endorsed by Proxmox staff here:
https://forum.proxmox.com/threads/how-does-keyctl-works-in-virtual-environments.116414/

Looks like it's only needed when running docker in the LXC. I think in this case we can add a check/flag during build to enable keyctl.


## Type of change

Please delete options that are not relevant.

