### PR TITLE
smokeping lxc container

### DIFF
--- a/ct/smokeping.sh
+++ b/ct/smokeping.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+   _____                 __        ____  _            
+  / ___/____ ___  ____  / /_____  / __ \(_)___  ____ _
+  \__ \/ __ `__ \/ __ \/ //_/ _ \/ /_/ / / __ \/ __ `/
+ ___/ / / / / / / /_/ / ,< /  __/ ____/ / / / / /_/ / 
+/____/_/ /_/ /_/\____/_/|_|\___/_/   /_/_/ /_/\__, /  
+                                             /____/   
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Smokeping"
+var_disk="2"
+var_cpu="1"
+var_ram="512"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+# Checking for Smokeping installation
+if ! command -v smokeping &> /dev/null; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+fi
+msg_info "Updating ${APP}"
+apt-get update &>/dev/null
+apt-get -y upgrade &>/dev/null
+msg_ok "Updated Successfully"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+         ${BL}http://${IP}/smokeping/smokeping.cgi${CL} \n"

--- a/install/smokeping-install.sh
+++ b/install/smokeping-install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# Update OS and install Smokeping and Apache without specific configuration
+msg_info "Updating OS and installing Smokeping and Apache"
+$STD apt-get update
+$STD apt-get install -y smokeping apache2 --no-install-recommends
+msg_ok "Smokeping and Apache installed"
+
+# Enable CGI module in Apache
+msg_info "Enabling CGI module in Apache"
+a2enmod cgi
+msg_ok "CGI module enabled"
+
+# Create a symlink for Smokeping Apache configuration if it doesn't already exist
+msg_info "Configuring Apache to serve Smokeping"
+if [ ! -f /etc/apache2/conf-available/smokeping.conf ]; then
+    ln -s /etc/smokeping/apache2.conf /etc/apache2/conf-available/smokeping.conf
+    msg_ok "Symlink for Smokeping configuration created"
+else
+    msg_info "Symlink for Smokeping configuration already exists"
+fi
+
+# Ensure the smokeping configuration is enabled
+a2enconf smokeping
+msg_ok "Apache configured for Smokeping"
+
+# Reload Apache to apply changes
+msg_info "Reloading Apache to apply changes"
+service apache2 restart
+msg_ok "Apache reloaded"
+
+# Basic setup steps to ensure Smokeping is operational
+msg_info "Ensuring Smokeping service is enabled and started"
+systemctl enable smokeping
+systemctl start smokeping
+msg_ok "Smokeping service operational"
+
+motd_ssh
+customize
+
+# Cleanup
+msg_info "Cleaning up"
+$STD apt-get autoremove -y
+$STD apt-get autoclean -y
+msg_ok "Cleanup complete"


### PR DESCRIPTION
## Description

Added [SmokePing](https://oss.oetiker.ch/smokeping/stats.en.html) LXC Container
Needs gh-pages info

Is functional out of the box, requires normal smokeping config steps.

[Config Examples](https://oss.oetiker.ch/smokeping/doc/smokeping_examples.en.html)
[Config Docs](https://oss.oetiker.ch/smokeping/doc/smokeping_config.en.html)

for example, basic setup;

`nano /etc/smokeping/config.d/Targets`

append targets
```
++ DefaultRouter0

menu = Router 192.168.0.1
title = 192.168.0.1 ICMP Latency
host = 192.168.0.1

++ Cloudflare

menu = Cloudflare 1.1.1.1
title = 1.1.1.1 ICMP Latency
host = 1.1.1.1
```

`systemctl restart smokeping`

SmokePing has a default 5min polling interval, so users won't see data immediately, but all product knowledge should of course be handled through the relevant documentation as this is just an installation script to kick-start an instance.

## Type of change

- [x] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
- [x] This change requires a documentation update
