### PR TITLE
Fix shell_check() to check if the current shell is bash

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -73,7 +73,7 @@ msg_error() {
 
 # Check if the shell is using bash
 shell_check() {
-  if [[ "$(basename "$SHELL")" != "bash" ]]; then
+  if [[ "$(basename "$0")" != "bash" ]]; then
     clear
     msg_error "Your default shell is currently not set to Bash. To use these scripts, please switch to the Bash shell."
     echo -e "\nExiting..."


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Please include a summary of the change and/or which issue is fixed. 

Change the shell_check to check the current shell, instead of the default shell. This ensures that the script must be ran within a bash shell (ie using `bash -c` like the copy/pasted script from the website) while not breaking when the default shell is something else.
Fixes #2740 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
