### PR TITLE
Fix openvino model generation in Frigate install script

### DIFF
--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -102,7 +102,8 @@ msg_info "Installing Object Detection Models (Resilience)"
 $STD pip install -r /opt/frigate/docker/main/requirements-ov.txt
 cd /opt/frigate/models
 export ENABLE_ANALYTICS=NO
-$STD /usr/local/bin/omz_downloader --name ssdlite_mobilenet_v2
+$STD /usr/local/bin/omz_downloader --name ssdlite_mobilenet_v2 --num_attempts 2
+$STD /usr/local/bin/omz_converter --name ssdlite_mobilenet_v2 --precision FP16 --mo /usr/local/bin/mo
 cd ..
 export CCACHE_DIR=/root/.ccache
 export CCACHE_MAXSIZE=2G

--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -18,9 +18,7 @@ $STD apt-get install -y {curl,sudo,mc,git,gpg,automake,build-essential,xz-utils,
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Python3 Dependencies"
-$STD apt-get install -y {python3,python3-dev,python3-setuptools,python3-distutils}
-wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py
-$STD python3 get-pip.py --quiet "pip"
+$STD apt-get install -y {python3,python3-dev,python3-setuptools,python3-distutils,python3-pip}
 msg_ok "Installed Python3 Dependencies"
 
 msg_info "Installing Node.js"


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

While debugging the install script step-by-step, I stumbled upon a few problems:

- the `get-pip.py` script did not install pip in a $PATH directory, so it couldn't be called directly. Getting pip from APT fixes this
- `omz_downloader` would fail on first try, maybe due to the Intel prompt to gather telemetry. Allowing 2 tries fixed this
- The script was missing `omz_converter` to generate the appropriate openvino model files

I have successfully tested the ssdlite_mobilenet_v2 with this config (default LXC settings except for unprivileged):

```
mqtt:
  enabled: false
detectors:
  ov:
    type: openvino
    device: AUTO
    model:
      path: /openvino-model/FP16/ssdlite_mobilenet_v2.xml
model:
  width: 300
  height: 300
  input_tensor: nhwc
  input_pixel_format: bgr
  labelmap_path: /openvino-model/coco_91cl_bkgr.txt
cameras:
  test:
    ffmpeg:
      #hwaccel_args: preset-vaapi
      inputs:
        - path: /media/frigate/person-bicycle-car-detection.mp4
          input_args: -re -stream_loop -1 -fflags +genpts
          roles:
            - detect
            - rtmp
    detect:
      height: 1080
      width: 1920
      fps: 5
```

Using openvino reduced the average CPU load significantly from 100% with the default cpu model to about 30% (My CPU is an AMD Ryzen 3700X)

![image](https://github.com/tteck/Proxmox/assets/9980037/000865a0-b63b-470f-8dcb-c28650813dd9)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
