### PR TITLE
Mount frigate video cache into memory to avoid hard drive overheating and overuse

### DIFF
--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -106,6 +106,7 @@ cameras:
 EOF
 ln -sf /config/config.yml /opt/frigate/config/config.yml
 sed -i -e 's/^kvm:x:104:$/render:x:104:root,frigate/' -e 's/^render:x:105:root$/kvm:x:105:/' /etc/group
+echo "tmpfs   /tmp/cache      tmpfs   defaults        0       0" >> /etc/fstab
 msg_ok "Installed Frigate $RELEASE"
 
 msg_info "Installing Object Detection Models (Resilience)"


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Use tmpfs to mount frigate video cache (`/tmp/cache`) into memory to avoid hard drive overheating and overuse

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
