### PR TITLE
[Frigate] Update Nginx config to output access and error logs to the service log file (/dev/shm)

### DIFF
--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -161,8 +161,8 @@ msg_ok "Installed Coral Object Detection Model"
 msg_info "Building Nginx with Custom Modules"
 $STD /opt/frigate/docker/main/build_nginx.sh
 sed -i 's/exec nginx/exec \/usr\/local\/nginx\/sbin\/nginx/g' /opt/frigate/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
-sed -i 's/error_log \/dev\/stdout warn\;/error_log nginx\.err warn\;/' /usr/local/nginx/conf/nginx.conf
-sed -i 's/access_log \/dev\/stdout main\;/access_log nginx\.log main\;/' /usr/local/nginx/conf/nginx.conf
+sed -i 's/error_log \/dev\/stdout warn\;/error_log syslog:server=unix:\/dev\/log\ warn\;/' /usr/local/nginx/conf/nginx.conf
+sed -i 's/access_log \/dev\/stdout main\;/access_log syslog:server=unix:\/dev\/log\ main\;/' /usr/local/nginx/conf/nginx.conf
 msg_ok "Built Nginx"
 
 msg_info "Creating Services"

--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -161,8 +161,8 @@ msg_ok "Installed Coral Object Detection Model"
 msg_info "Building Nginx with Custom Modules"
 $STD /opt/frigate/docker/main/build_nginx.sh
 sed -i 's/exec nginx/exec \/usr\/local\/nginx\/sbin\/nginx/g' /opt/frigate/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
-sed -i 's/error_log \/dev\/stdout warn\;/error_log syslog:server=unix:\/dev\/log\ warn\;/' /usr/local/nginx/conf/nginx.conf
-sed -i 's/access_log \/dev\/stdout main\;/access_log syslog:server=unix:\/dev\/log\ main\;/' /usr/local/nginx/conf/nginx.conf
+sed -i 's/error_log \/dev\/stdout warn\;/error_log \/dev\/shm\/logs\/nginx\/current warn\;/' /usr/local/nginx/conf/nginx.conf
+sed -i 's/access_log \/dev\/stdout main\;/access_log \/dev\/shm\/logs\/nginx\/current main\;/' /usr/local/nginx/conf/nginx.conf
 msg_ok "Built Nginx"
 
 msg_info "Creating Services"


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Nginx detailed logs were saved to a different file and were not showing up in the web interface of frigate. They now log into `/dev/shm/nginx/current`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
