### PR TITLE
feat: script improvement on routerOS and OpenWRT

### DIFF
--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -62,7 +62,7 @@ function cleanup() {
 }
 TEMP_DIR=$(mktemp -d)
 pushd $TEMP_DIR >/dev/null
- if ! pveversion | grep -Eq "pve-manager/(7.4-[1][3-9]|8.1.[1-9]|8.2.[1-9])"; then
+ if ! pveversion | grep -Eq "pve-manager/(7\.4-(1[3-8])|8\.[1-2])"; then
   echo "⚠ This version of Proxmox Virtual Environment is not supported"
   echo -e "Requires PVE7 Version 7.4-13 or later, or PVE8 Version 8.1.1 or later."
   echo "Exiting..."

--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -62,7 +62,7 @@ function cleanup() {
 }
 TEMP_DIR=$(mktemp -d)
 pushd $TEMP_DIR >/dev/null
- if ! pveversion | grep -Eq "pve-manager/(7.4-[1][3-9]|8.1.[1-9])"; then
+ if ! pveversion | grep -Eq "pve-manager/(7.4-[1][3-9]|8.1.[1-9]|8.2.[1-9])"; then
   echo "⚠ This version of Proxmox Virtual Environment is not supported"
   echo -e "Requires PVE7 Version 7.4-13 or later, or PVE8 Version 8.1.1 or later."
   echo "Exiting..."

--- a/vm/openwrt.sh
+++ b/vm/openwrt.sh
@@ -475,6 +475,7 @@ qm set $VMID \
   -efidisk0 ${DISK0_REF},efitype=4m,size=4M \
   -scsi0 ${DISK1_REF},size=512M \
   -boot order=scsi0 \
+  -tags proxmox-helper-scripts \
   -description "<div align='center'><a href='https://Helper-Scripts.com'><img src='https://raw.githubusercontent.com/tteck/Proxmox/main/misc/images/logo-81x112.png'/></a>
 
   # OpenWRT


### PR DESCRIPTION
Hey!

## Description

This MR brings two things:
- RouterOS was not allowed to install on my instance because I have the latest release of Proxmox. I tested the installation and all seems good.
- OpenWRT script does not add the tag on the VM where others script do.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [ ] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
- [ ] This change requires a documentation update


Thank you for you work!