### PR TITLE
Replace pnpm with yarn in Nginx Proxy Manager LXC installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 - All LXC instances created using this repository come pre-installed with Midnight Commander, which is a command-line tool (`mc`) that offers a user-friendly file and directory management interface for the terminal environment.
 - 🚨 **The scripts in the repository will no longer provide support for Proxmox VE 7 starting from July 2024 (scripts will not execute on PVE7). Subsequent <a href='https://forum.proxmox.com/threads/proxmox-ve-support-lifecycle.35755/' target='_blank' rel='noopener noreferrer'>Proxmox VE - Support Lifecycle</a>**
 
+## 2024-05-04
+
+### Changed
+
+- **Nginx Proxy Manager LXC**
+  - Use `yarn` as default node package manager
+
 ## 2024-05-02
 
 ### Changed

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -59,11 +59,11 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  if ! command -v pnpm &> /dev/null; then  
-    msg_info "Installing pnpm"
+  if ! command -v yarn &> /dev/null; then  
+    msg_info "Installing yarn"
     export NODE_OPTIONS=--openssl-legacy-provider
-    npm install -g pnpm@8.15 &>/dev/null
-    msg_ok "Installed pnpm"
+    npm install -g yarn@1.22.19 &>/dev/null
+    msg_ok "Installed yarn"
   fi
   RELEASE=$(curl -s https://api.github.com/repos/NginxProxyManager/nginx-proxy-manager/releases/latest |
     grep "tag_name" |
@@ -138,9 +138,8 @@ function update_script() {
 
   msg_info "Building Frontend"
   cd ./frontend
-  pnpm install &>/dev/null
-  pnpm upgrade &>/dev/null
-  pnpm run build &>/dev/null
+  yarn ci &>/dev/null
+  yarn run build &>/dev/null
   cp -r dist/* /app/frontend
   cp -r app-images/* /app/frontend/images
   msg_ok "Built Frontend"
@@ -163,7 +162,7 @@ function update_script() {
 EOF
   fi
   cd /app
-  pnpm install &>/dev/null
+  yarn ci &>/dev/null
   msg_ok "Initialized Backend"
 
   msg_info "Starting Services"

--- a/install/nginxproxymanager-install.sh
+++ b/install/nginxproxymanager-install.sh
@@ -59,9 +59,9 @@ $STD nvm install 16.20.2
 ln -sf /root/.nvm/versions/node/v16.20.2/bin/node /usr/bin/node
 msg_ok "Installed Node.js"
 
-msg_info "Installing pnpm"
-$STD npm install -g pnpm@8.15
-msg_ok "Installed pnpm"
+msg_info "Installing yarn"
+$STD npm install -g yarn@1.22.19
+msg_ok "Installed yarn"
 
 RELEASE=$(curl -s https://api.github.com/repos/NginxProxyManager/nginx-proxy-manager/releases/latest |
   grep "tag_name" |
@@ -140,9 +140,8 @@ msg_ok "Set up Enviroment"
 
 msg_info "Building Frontend"
 cd ./frontend
-$STD pnpm install
-$STD pnpm upgrade
-$STD pnpm run build
+$STD yarn ci
+$STD yarn run build
 cp -r dist/* /app/frontend
 cp -r app-images/* /app/frontend/images
 msg_ok "Built Frontend"
@@ -165,7 +164,7 @@ if [ ! -f /app/config/production.json ]; then
 EOF
 fi
 cd /app
-$STD pnpm install
+$STD yarn ci
 msg_ok "Initialized Backend"
 
 msg_info "Creating Service"


### PR DESCRIPTION
## tl;dr
Because of faulty `pnpm` execution during an installment of *Ngnix Proxy Manager LXC* I have replaced it with `yarn` [as pointed here](https://github.com/NginxProxyManager/nginx-proxy-manager/blob/79cd0c5294f1e3ad4cc9ed5187b7759808b91162/frontend/yarn.lock#L2)

## Motivation
During the installation of the *Nginx Proxy Manager LXC* I stumbled upon an issue about a segmentation fault. After careful investigation, it happened that `pnpm` was throwing this error when trying to update packages. I have analyzed the Ngnix Proxy Manager frontend package and it is configured to use `yarn` by default, so I have adjusted the scripts responsible for the installation of the frontend. Moreover, I have applied clean install instead of install and removed package upgrade as it is generally not safe to bump packages automatically and we should use the same packages as the provider delivers in yarn.lock.

P.S. The issue with Seg fault was happening always until the writing of this PR to provide screenshots, nevertheless, the installation process will be even more perfect when using yarn instead of pnpm on the container.

### Fixes
- Installation of *Nginx Proxy Manager LXC*

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.


