### PR TITLE
avoid warning messages in cron logs

### DIFF
--- a/misc/update-lxcs-cron.sh
+++ b/misc/update-lxcs-cron.sh
@@ -22,7 +22,7 @@ function update_container() {
   alpine) pct exec "$container" -- ash -c "apk update && apk upgrade" ;;
   archlinux) pct exec "$container" -- bash -c "pacman -Syyu --noconfirm" ;;
   fedora | rocky | centos | alma) pct exec "$container" -- bash -c "dnf -y update && dnf -y upgrade" ;;
-  ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt list --upgradable && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" dist-upgrade -y" ;;
+  ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt -o Apt::Cmd::Disable-Script-Warning=true list --upgradable && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" dist-upgrade -y" ;;
   esac
 }
 

--- a/misc/update-lxcs-cron.sh
+++ b/misc/update-lxcs-cron.sh
@@ -22,7 +22,7 @@ function update_container() {
   alpine) pct exec "$container" -- ash -c "apk update && apk upgrade" ;;
   archlinux) pct exec "$container" -- bash -c "pacman -Syyu --noconfirm" ;;
   fedora | rocky | centos | alma) pct exec "$container" -- bash -c "dnf -y update && dnf -y upgrade" ;;
-  ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt -o Apt::Cmd::Disable-Script-Warning=true list --upgradable && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" dist-upgrade -y" ;;
+  ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt-get upgrade --dry-run && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" dist-upgrade -y" ;;
   esac
 }
 


### PR DESCRIPTION
## Description

Add -o Apt::Cmd::Disable-Script-Warning=true argument to the `apt` call, to avoid the "WARNING: apt does not have a stable CLI interface. Use with caution in scripts." messages that otherwise would be printed in the cron logs.

Fixes  #2931

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
