### PR TITLE
Changed the PVE 8 upgrade script to actually check the version

### DIFF
--- a/misc/pve8-upgrade.sh
+++ b/misc/pve8-upgrade.sh
@@ -124,7 +124,7 @@ if ! command -v pveversion >/dev/null 2>&1; then
   exit
 fi
 
-if ! pveversion | grep -Eq "pve-manager/(7\.4-(13|14|15|16|17))"; then
+if ! pveversion | grep -Eq "pve-manager/(7\.4-(1[3-9]|[2-9]\d))"; then
   header_info
   msg_error "This version of Proxmox Virtual Environment is not supported"
   echo -e "  PVE Version 7.4-13 or higher is required."


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Changed the pve8-upgrade.sh script to actually check if the version is higher than PVE 7.4-13
This fixes a bug where versions originally not in the script (e.g. the newest version PVE 7.4-18) could not be upgraded to PVE 8

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
