### PR TITLE
Fixed Traefik : forgot to remove Crowdsec middleware in default config

### DIFF
--- a/install/traefik-install.sh
+++ b/install/traefik-install.sh
@@ -48,8 +48,6 @@ entryPoints:
   websecure:
     address: ':443'
     http:
-      middlewares:
-        - crowdsec-bouncer@file
       tls:
         certResolver: letsencrypt
   traefik:


### PR DESCRIPTION
## Description

I used my Traefik's configuration file, removing unwanted elements, forgot to remove the crowdsec-bouncer middleware, which will result in 403 for every router...

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
