### PR TITLE
Ensure logrotate doesn't use non-existing npm user

### DIFF
--- a/install/nginxproxymanager-install.sh
+++ b/install/nginxproxymanager-install.sh
@@ -193,6 +193,7 @@ customize
 
 msg_info "Starting Services"
 sed -i 's/user npm/user root/g; s/^pid/#pid/g' /usr/local/openresty/nginx/conf/nginx.conf
+sed -r -i 's/^([[:space:]]*)su npm npm/\1#su npm npm/g;' /etc/logrotate.d/nginx-proxy-manager
 sed -i 's/include-system-site-packages = false/include-system-site-packages = true/g' /opt/certbot/pyvenv.cfg
 systemctl enable -q --now openresty
 systemctl enable -q --now npm


### PR DESCRIPTION
## Description

Upstream uses a dedicated user to run NPM. Ensure logrotate does not try to use that missing user to rotate the NPM logs [which would fail].

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
