### PR TITLE
Discussion #3030 Fix

### DIFF
--- a/ct/traefik.sh
+++ b/ct/traefik.sh
@@ -60,7 +60,7 @@ msg_info "Updating $APP LXC"
 if [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]] || [[ ! -f /opt/${APP}_version.txt ]]; then
   wget -q https://github.com/traefik/traefik/releases/download/v${RELEASE}/traefik_v${RELEASE}_linux_amd64.tar.gz
   tar -C /tmp -xzf traefik*.tar.gz
-  mv /tmp/traefik*/traefik /usr/bin/
+  mv /tmp/traefik /usr/bin/
   rm -rf traefik*.tar.gz
   msg_ok "Updated $APP LXC"
 else


### PR DESCRIPTION
## Description

Fixes #3030
```
/mv: cannot stat '/tmp/traefik*/traefik': No such file or directory

[ERROR] in line 63: exit code 0: while executing command mv /tmp/traefik*/traefik /usr/bin/
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
