### PR TITLE
Disable "running as root" warning in Jackett WebUI/Logs

### DIFF
--- a/install/jackett-install.sh
+++ b/install/jackett-install.sh
@@ -39,6 +39,7 @@ Type=simple
 WorkingDirectory=/opt/Jackett
 ExecStart=/bin/sh /opt/Jackett/jackett_launcher.sh
 TimeoutStopSec=30
+Environment="DisableRootWarning=true"
 [Install]
 WantedBy=multi-user.target
 EOF


### PR DESCRIPTION
## Description

Upstream checks if running under root and displays alert in both startup logs and WebUI. This environment variable disables that behavior.

Fixes # (issue)

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
