### PR TITLE
Update photoprism-install.sh

### DIFF
--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -26,6 +26,7 @@ $STD apt-get install -y libtiff-dev
 $STD apt-get install -y imagemagick
 $STD apt-get install -y darktable
 $STD apt-get install -y rawtherapee
+$STD apt-get install -y libvips42
 
 echo 'export PATH=/usr/local:$PATH' >>~/.bashrc
 export PATH=/usr/local:$PATH


### PR DESCRIPTION
Latest photoprism has a new dependency.  It will not install nor start due to this issue.
```
✓ Installed Dependencies
 ✓ Installed PhotoPrism
 \ Creating Service   
[ERROR] in line 72: exit code 0: while executing command systemctl enable -q --now photoprism
```
This is the underlying problem.
```
x photoprism.service - PhotoPrism service
     Loaded: loaded (/etc/systemd/system/photoprism.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Thu 2024-05-23 16:46:22 EDT; 1min 39s ago
    Process: 11653 ExecStart=/opt/photoprism/bin/photoprism up -d (code=exited, status=127)
        CPU: 492us

May 23 16:46:22 photoprism systemd[1]: Starting photoprism.service - PhotoPrism service...
May 23 16:46:22 photoprism photoprism[11653]: /opt/photoprism/bin/photoprism: error while loading shared libraries: libvips.so.42: cannot open shared object file: No such file or directory
May 23 16:46:22 photoprism systemd[1]: photoprism.service: Control process exited, code=exited, status=127/n/a
May 23 16:46:22 photoprism systemd[1]: photoprism.service: Failed with result 'exit-code'.
May 23 16:46:22 photoprism systemd[1]: Failed to start photoprism.service - PhotoPrism service.

```
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Include a new dependent library required by the latest version of photoprism. 

Fixes # (issue)

I was unable to submit an issue on your site (submit button remained greyed out) - I forked and issue a pull.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

