### PR TITLE
Correct ceph enterprise urls

### DIFF
--- a/misc/post-pve-install.sh
+++ b/misc/post-pve-install.sh
@@ -105,9 +105,9 @@ EOF
     yes)
       msg_info "Correcting 'ceph package repositories'"
       cat <<EOF >/etc/apt/sources.list.d/ceph.list
-# deb http://download.proxmox.com/debian/ceph-quincy bookworm enterprise
+# deb https://enterprise.proxmox.com/debian/ceph-quincy bookworm enterprise
 # deb http://download.proxmox.com/debian/ceph-quincy bookworm no-subscription
-# deb http://download.proxmox.com/debian/ceph-reef bookworm enterprise
+# deb https://enterprise.proxmox.com/debian/ceph-reef bookworm enterprise
 # deb http://download.proxmox.com/debian/ceph-reef bookworm no-subscription
 EOF
       msg_ok "Corrected 'ceph package repositories'"

--- a/misc/pve8-upgrade.sh
+++ b/misc/pve8-upgrade.sh
@@ -73,7 +73,7 @@ EOF
   whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "PVE8 CEPH PACKAGE REPOSITORIES" "The 'Ceph Package Repositories' provides access to both the 'no-subscription' and 'enterprise' repositories." 10 58
     msg_info "Enabling 'ceph package repositories'"
     cat <<EOF >/etc/apt/sources.list.d/ceph.list
-# deb http://download.proxmox.com/debian/ceph-quincy bookworm enterprise
+# deb https://enterprise.proxmox.com/debian/ceph-quincy bookworm enterprise
 deb http://download.proxmox.com/debian/ceph-quincy bookworm no-subscription
 EOF
     msg_ok "Enabled 'ceph package repositories'"


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Corrects the Enterprise Ceph repo urls to match the [documented ones](https://pve.proxmox.com/wiki/Package_Repositories#sysadmin_package_repositories_ceph)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
