### PR TITLE
Fix YtDL_Options (Filename to long)

### DIFF
--- a/install/metube-install.sh
+++ b/install/metube-install.sh
@@ -19,6 +19,11 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y --no-install-recommends \
   build-essential \
   curl \
+  aria2 \
+  coreutils \
+  gcc \
+  g++ \
+  musl-dev \
   sudo \
   ffmpeg \
   git \

--- a/install/metube-install.sh
+++ b/install/metube-install.sh
@@ -60,6 +60,7 @@ cat <<EOF >/opt/metube/.env
 DOWNLOAD_DIR=/opt/metube_downloads
 STATE_DIR=/opt/metube_downloads/.metube
 TEMP_DIR=/opt/metube_downloads
+YTDL_OPTIONS={"trim_file_name":10}
 EOF
 msg_ok "Installed MeTube"
 


### PR DESCRIPTION
**Fixes # (issue)**
Added an Fix for to long filenames for bare tail debian installation.
Specially for Twitter/X Downloads
The fix is just an enhancement in the .env file. The bug has been known since 2021. I have tested it so far and it works.

+ added some dependencies for twitter, tiktok and so on

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
