### PR TITLE
Add new LXC: MySpeed

### DIFF
--- a/ct/myspeed.sh
+++ b/ct/myspeed.sh
@@ -55,14 +55,14 @@ function default_settings() {
 }
 
 function update_script() {
-  header_info
-  if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-  if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
-    read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
-    [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
-  fi
-  RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
-  if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+header_info
+if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
+fi
+RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
+if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
 
   msg_info "Stopping ${APP} Service"
   systemctl stop myspeed
@@ -88,9 +88,9 @@ function update_script() {
   msg_ok "Cleaned"
 
   msg_ok "Updated Successfully!\n"
-  else
+else
   msg_ok "No update required. ${APP} is already at ${RELEASE}"
-  fi
+fi
 exit
 }
 

--- a/ct/myspeed.sh
+++ b/ct/myspeed.sh
@@ -55,43 +55,43 @@ function default_settings() {
 }
 
 function update_script() {
-	header_info
-	if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-	if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
-	  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
-	  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
-	fi
-	RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
-	if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
-		msg_info "Stopping ${APP} Service"
-		systemctl stop myspeed
-		msg_ok "Stopped ${APP} Service"
+  header_info
+  if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+  if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+    read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+    [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
+  fi
+  RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
+  if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
 
-		msg_info "Updating ${APP} to ${RELEASE}"
-		cd /opt
-		rm -rf myspeed_bak
-		mv myspeed myspeed_bak
-		wget -q https://github.com/gnmyt/myspeed/releases/download/v$RELEASE/MySpeed-$RELEASE.zip
-		unzip -q MySpeed-$RELEASE.zip -d myspeed
-		cd myspeed
-		npm install >/dev/null 2>&1
-		echo "${RELEASE}" >/opt/${APP}_version.txt
+  msg_info "Stopping ${APP} Service"
+  systemctl stop myspeed
+  msg_ok "Stopped ${APP} Service"
 
-		msg_ok "Updated ${APP} to ${RELEASE}"
+  msg_info "Updating ${APP} to ${RELEASE}"
+  cd /opt
+  rm -rf myspeed_bak
+  mv myspeed myspeed_bak
+  wget -q https://github.com/gnmyt/myspeed/releases/download/v$RELEASE/MySpeed-$RELEASE.zip
+  unzip -q MySpeed-$RELEASE.zip -d myspeed
+  cd myspeed
+  npm install >/dev/null 2>&1
+  echo "${RELEASE}" >/opt/${APP}_version.txt
+  msg_ok "Updated ${APP} to ${RELEASE}"
 
-		msg_info "Starting ${APP} Service"
-		systemctl start myspeed
-		msg_ok "Started ${APP} Service"
+  msg_info "Starting ${APP} Service"
+  systemctl start myspeed
+  msg_ok "Started ${APP} Service"
 
-		msg_info "Cleaning up"
-		rm -rf MySpeed-$RELEASE.zip
-		msg_ok "Cleaned"
+  msg_info "Cleaning up"
+  rm -rf MySpeed-$RELEASE.zip
+  msg_ok "Cleaned"
 
-		msg_ok "Updated Successfully!\n"
-	else
-		msg_ok "No update required. ${APP} is already at ${RELEASE}"
-	fi
-	exit
+  msg_ok "Updated Successfully!\n"
+  else
+  msg_ok "No update required. ${APP} is already at ${RELEASE}"
+  fi
+exit
 }
 
 start

--- a/ct/myspeed.sh
+++ b/ct/myspeed.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: MickLesk (Canbiz)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+    __  ___      _____                     __
+   /  |/  /_  __/ ___/____  ___  ___  ____/ /
+  / /|_/ / / / /\__ \/ __ \/ _ \/ _ \/ __  / 
+ / /  / / /_/ /___/ / /_/ /  __/  __/ /_/ /  
+/_/  /_/\__, //____/ .___/\___/\___/\__,_/   
+       /____/     /_/                        
+	   
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="MySpeed"
+var_disk="4"
+var_cpu="1"
+var_ram="1024"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
+fi
+RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
+if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+
+msg_info "Stopping ${APP} Service"
+systemctl stop myspeed
+msg_ok "Stopped ${APP} Service"
+
+msg_info "Updating ${APP} to ${RELEASE}"
+cd /opt
+rm -rf myspeed_bak
+mv myspeed myspeed_bak
+wget -q https://github.com/gnmyt/myspeed/releases/download/v$RELEASE/MySpeed-$RELEASE.zip
+unzip -q MySpeed-$RELEASE.zip -d myspeed
+cd myspeed
+npm install >/dev/null 2>&1
+echo "${RELEASE}" >/opt/${APP}_version.txt
+
+msg_ok "Updated ${APP} to ${RELEASE}"
+
+  msg_info "Starting ${APP} Service"
+  systemctl start myspeed
+  msg_ok "Started ${APP} Service"
+
+  msg_info "Cleaning up"
+  rm -rf MySpeed-$RELEASE.zip
+  msg_ok "Cleaned"
+
+  msg_ok "Updated Successfully!\n"
+else
+  msg_ok "No update required. ${APP} is already at ${RELEASE}"
+fi
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} Setup should be reachable by going to the following URL.
+         ${BL}http://${IP}:5216${CL} \n"

--- a/ct/myspeed.sh
+++ b/ct/myspeed.sh
@@ -55,44 +55,43 @@ function default_settings() {
 }
 
 function update_script() {
-header_info
-if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
-  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
-  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
-fi
-RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
-if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+	header_info
+	if [[ ! -d /opt/myspeed ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+	if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+	  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+	  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
+	fi
+	RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
+	if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+		msg_info "Stopping ${APP} Service"
+		systemctl stop myspeed
+		msg_ok "Stopped ${APP} Service"
 
-msg_info "Stopping ${APP} Service"
-systemctl stop myspeed
-msg_ok "Stopped ${APP} Service"
+		msg_info "Updating ${APP} to ${RELEASE}"
+		cd /opt
+		rm -rf myspeed_bak
+		mv myspeed myspeed_bak
+		wget -q https://github.com/gnmyt/myspeed/releases/download/v$RELEASE/MySpeed-$RELEASE.zip
+		unzip -q MySpeed-$RELEASE.zip -d myspeed
+		cd myspeed
+		npm install >/dev/null 2>&1
+		echo "${RELEASE}" >/opt/${APP}_version.txt
 
-msg_info "Updating ${APP} to ${RELEASE}"
-cd /opt
-rm -rf myspeed_bak
-mv myspeed myspeed_bak
-wget -q https://github.com/gnmyt/myspeed/releases/download/v$RELEASE/MySpeed-$RELEASE.zip
-unzip -q MySpeed-$RELEASE.zip -d myspeed
-cd myspeed
-npm install >/dev/null 2>&1
-echo "${RELEASE}" >/opt/${APP}_version.txt
+		msg_ok "Updated ${APP} to ${RELEASE}"
 
-msg_ok "Updated ${APP} to ${RELEASE}"
+		msg_info "Starting ${APP} Service"
+		systemctl start myspeed
+		msg_ok "Started ${APP} Service"
 
-  msg_info "Starting ${APP} Service"
-  systemctl start myspeed
-  msg_ok "Started ${APP} Service"
+		msg_info "Cleaning up"
+		rm -rf MySpeed-$RELEASE.zip
+		msg_ok "Cleaned"
 
-  msg_info "Cleaning up"
-  rm -rf MySpeed-$RELEASE.zip
-  msg_ok "Cleaned"
-
-  msg_ok "Updated Successfully!\n"
-else
-  msg_ok "No update required. ${APP} is already at ${RELEASE}"
-fi
-exit
+		msg_ok "Updated Successfully!\n"
+	else
+		msg_ok "No update required. ${APP} is already at ${RELEASE}"
+	fi
+	exit
 }
 
 start

--- a/install/myspeed-install.sh
+++ b/install/myspeed-install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: MickLesk (Canbiz)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+# Source: https://github.com/gnmyt/myspeed
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  curl \
+  sudo \
+  make \
+  gpg \
+  ca-certificates \
+  mc
+msg_ok "Installed Dependencies"
+
+msg_info "Setting up Node.js Repository"
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+msg_ok "Set up Node.js Repository"
+
+msg_info "Installing Node.js"
+$STD apt-get update
+$STD apt-get install -y nodejs
+msg_ok "Installed Node.js"
+
+msg_info "Installing MySpeed"
+RELEASE=$(wget -q https://github.com/gnmyt/myspeed/releases/latest -O - | grep "title>Release" | cut -d " " -f 5)
+cd /opt
+wget -q https://github.com/gnmyt/myspeed/releases/download/v$RELEASE/MySpeed-$RELEASE.zip
+unzip -q MySpeed-$RELEASE.zip -d myspeed
+cd myspeed
+$STD npm install
+echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
+msg_ok "Installed MySpeed"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/myspeed.service
+[Unit]
+Description=MySpeed
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/node server
+Restart=always
+User=root
+Environment=NODE_ENV=production
+WorkingDirectory=/opt/myspeed 
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now myspeed.service
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+rm -rf /opt/MySpeed-$RELEASE.zip
+$STD apt-get -y autoclean
+msg_ok "Cleaned"


### PR DESCRIPTION
## Description
- New LXC for MySpeed (Speed Testing)
- Tested and works fine

![image](https://github.com/tteck/Proxmox/assets/47820557/1c7c765a-5fa1-4429-a48d-178e7eced7a4)

Software: 
https://github.com/gnmyt/myspeed
MySpeed is a speed test analysis software that records your internet speed for up to 30 days.
MySpeed generates clear statistics on speed, ping, and more
MySpeed automates speed tests and allows you to set the time between tests using Cron expressions
Add multiple servers directly to a MySpeed instance
Configure health checks to notify you via email, Signal, WhatsApp, or Telegram in case of errors or downtime
Test results can be stored for up to 30 days
Support for Prometheus and Grafana


## Type of change

- [x] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
- [x] This change requires a documentation update
