### PR TITLE
Add New LXC: Ollama

### DIFF
--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 ulmentflam
+# Author: ulmentflam
+# License: MIT
+# https://github.com/ulmentflam/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+ ________  ___       ___       ________  _____ ______   ________
+|\   __  \|\  \     |\  \     |\   __  \|\   _ \  _   \|\   __  \
+\ \  \|\  \ \  \    \ \  \    \ \  \|\  \ \  \\\__\ \  \ \  \|\  \
+ \ \  \\\  \ \  \    \ \  \    \ \   __  \ \  \\|__| \  \ \   __  \
+  \ \  \\\  \ \  \____\ \  \____\ \  \ \  \ \  \    \ \  \ \  \ \  \
+   \ \_______\ \_______\ \_______\ \__\ \__\ \__\    \ \__\ \__\ \__\
+    \|_______|\|_______|\|_______|\|__|\|__|\|__|     \|__|\|__|\|__|
+
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Ollama"
+var_disk="8"
+var_cpu="2"
+var_ram="2048"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -f /etc/systemd/system/ollama.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Updating $APP LXC"
+apt-get update &>/dev/null
+curl -fsSL https://ollama.com/install.sh | sh
+msg_ok "Updated $APP LXC"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+         ${BL}http://${IP}:11434${CL} \n"

--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
-# Copyright (c) 2021-2024 ulmentflam
-# Author: ulmentflam
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: ulmentflam
 # License: MIT
-# https://github.com/ulmentflam/Proxmox/raw/main/LICENSE
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
 
 function header_info {
 clear

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -30,9 +30,9 @@ Description=Ollama Service
 After=network-online.target
 
 [Service]
+Type=simple
+UMask=007
 ExecStart=/usr/bin/ollama serve
-User=ollama
-Group=ollama
 Restart=always
 RestartSec=3
 

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -22,6 +22,7 @@ msg_ok "Installed Dependencies"
 
 msg_info "Installing Ollama"
 $STD curl -fsSL https://ollama.com/install.sh | sh
+
 msg_ok "Installed Ollama"
 
 msg_info "Creating Service"
@@ -32,14 +33,13 @@ After=network-online.target
 
 [Service]
 Type=simple
-UMask=007
 ExecStart=/usr/bin/ollama serve
 Restart=always
 RestartSec=3
 
 [Install]
 WantedBy=multi-user.target" >$service_path
-systemctl enable --now -q ollama
+systemctl enable -q --now ollama.service
 msg_ok "Created Service"
 
 motd_ssh

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 ulmentflam
+# Author: ulmentflam
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl
+$STD apt-get install -y sudo
+$STD apt-get install -y build-essential
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Ollama"
+$STD curl -fsSL https://ollama.com/install.sh | sh
+msg_ok "Installed Ollama"
+
+msg_info "Creating Service"
+service_path="/etc/systemd/system/ollama.service"
+echo "[Unit]
+Description=Ollama Service
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/ollama serve
+User=ollama
+Group=ollama
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target" >$service_path
+systemctl daemon-reload
+systemctl enable --now -q ollama
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -39,7 +39,6 @@ RestartSec=3
 
 [Install]
 WantedBy=multi-user.target" >$service_path
-systemctl daemon-reload
 systemctl enable --now -q ollama
 msg_ok "Created Service"
 

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2021-2024 ulmentflam
-# Author: ulmentflam
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: ulmentflam
 # License: MIT
 # https://github.com/tteck/Proxmox/raw/main/LICENSE
 

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -16,6 +16,7 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y curl
 $STD apt-get install -y sudo
+$STD apt-get install -y mc
 $STD apt-get install -y build-essential
 msg_ok "Installed Dependencies"
 

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -17,30 +17,12 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
-$STD apt-get install -y build-essential
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Ollama"
+msg_info "Installing Ollama & Creating Service"
 $STD curl -fsSL https://ollama.com/install.sh | sh
-
-msg_ok "Installed Ollama"
-
-msg_info "Creating Service"
-service_path="/etc/systemd/system/ollama.service"
-echo "[Unit]
-Description=Ollama Service
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/ollama serve
-Restart=always
-RestartSec=3
-
-[Install]
-WantedBy=multi-user.target" >$service_path
 systemctl enable -q --now ollama.service
-msg_ok "Created Service"
+msg_ok "Installed Ollama & Created Service"
 
 motd_ssh
 customize


### PR DESCRIPTION
## Description

This PR adds Ollama as an LXC. Ollama is a self-hosted API for running large language models. It supports the open Llama Models, Phi, Minstral, Gemma, and more. This LXC benefits from GPU passthrough and installation of GPU drivers. 

## Type of change

- [x] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
- [x] This change requires a documentation update
