### PR TITLE
Fix mikrotik-routeros when using nfs

### DIFF
--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -254,13 +254,12 @@ nfs | dir)
 btrfs | zfspool)
   DISK_EXT=""
   DISK_REF="$VMID/"
-  DISK_FORMAT="subvol"
   DISK_IMPORT="-format raw"
   ;;
 esac
 
 DISK_VAR="vm-${VMID}-disk-0${DISK_EXT:-}"
-DISK_REF="${STORAGE}:${DISK_VAR:-}"
+DISK_REF="${STORAGE}:${DISK_REF:-}${DISK_VAR:-}"
 
 msg_ok "Extracted Mikrotik RouterOS CHR Disk Image"
 msg_info "Creating Mikrotik RouterOS CHR VM"


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

When using NFS as the storage option, the mikrotik-routeros script currently fails.

Screenshot of failure:
![Screenshot 2024-06-21 at 4 57 09 PM](https://github.com/tteck/Proxmox/assets/7609029/2db3451c-31b2-4035-8086-c916502e16f0)

I compared this script against several others in the `vm/` directory and noticed that this one was not including the `$VMID/` portion in its `$DISK_REF`. Adding it in fixes the error I was running into:
![Screenshot 2024-06-21 at 4 57 49 PM](https://github.com/tteck/Proxmox/assets/7609029/7ca72904-cd4b-4308-9c8d-3fbf9eaefc5b)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
