### PR TITLE
Update bunkerweb-install.sh script with the new NGINX (1.26.1) and BunkerWeb (1.5.8) versions

### DIFF
--- a/install/bunkerweb-install.sh
+++ b/install/bunkerweb-install.sh
@@ -23,19 +23,19 @@ $STD apt-get install -y lsb-release
 $STD apt-get install -y debian-archive-keyring
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Nginx v1.20.0"
-wget -qO- https://nginx.org/keys/nginx_signing.key | gpg --dearmor >/usr/share/keyrings/nginx-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian `lsb_release -cs` nginx" >/etc/apt/sources.list.d/nginx.list
+msg_info "Installing Nginx v1.26.1"
+curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | $STD tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian `lsb_release -cs` nginx" | $STD tee /etc/apt/sources.list.d/nginx.list
 $STD apt-get update
-$STD apt-get install -y nginx=1.24.0-1~$(lsb_release -cs)
-msg_ok "Installed Nginx v1.20.0"
+$STD apt-get install -y nginx=1.26.1-2~$(lsb_release -cs)
+msg_ok "Installed Nginx v1.26.1"
 
-msg_info "Installing BunkerWeb v1.5.7"
+msg_info "Installing BunkerWeb v1.5.8"
 export UI_WIZARD=1
-curl -sSL https://packagecloud.io/install/repositories/bunkerity/bunkerweb/script.deb.sh | bash &>/dev/null
-$STD apt-get install -y bunkerweb=1.5.7
-#$STD apt-mark hold nginx bunkerweb
-msg_ok "Installed BunkerWeb v1.5.7"
+curl -s https://packagecloud.io/install/repositories/bunkerity/bunkerweb/script.deb.sh | $STD bash &>/dev/null
+$STD -E apt-get install -y bunkerweb=1.5.8
+$STD apt-mark hold nginx bunkerweb
+msg_ok "Installed BunkerWeb v1.5.8"
 
 motd_ssh
 customize


### PR DESCRIPTION
## Description

Updated BunkerWeb to the latest version (1.5.8) which requires NGINX (1.26.1).
I also added the `apt-mark hold nginx bunkerweb` command back to avoid potential issues with automatic upgrades.

## Type of change

Please delete options that are not relevant.

- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
