### PR TITLE
Adds a version.txt file to record the installed version.

### DIFF
--- a/install/pocketbase-install.sh
+++ b/install/pocketbase-install.sh
@@ -25,6 +25,9 @@ wget -q https://github.com/pocketbase/pocketbase/releases/download/v${RELEASE}/p
 mkdir -p /opt/pocketbase/{pb_public,pb_migrations,pb_hooks}
 unzip -q -o /tmp/pocketbase.zip -d /opt/pocketbase
 
+# Create a file with the version information
+echo "Pocketbase version: ${RELEASE}" > /opt/pocketbase/version.txt
+
 cat <<EOF >/etc/systemd/system/pocketbase.service
 [Unit]
 Description = pocketbase


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description
This creates a version.txt file in the root of the pocketbase directory allowing for easy identification of the currently installed PocketBase version.
Please include a summary of the change and/or which issue is fixed. 

Fixes # (issue)

## Type of change
This is a simple one line addition to add a `version.txt` file at the base of the `pocketbase` directory to allow one to easily identify the currently installed version of PocketBase. This stems from me seeking assistance with a question that had about PocketBase and being asked "What version are you running?". I was already in the server PocketBase directory making changes so I searched for version info there and found none. 

This addition saves a user from needing to open up a browser, navigate to the admin dashboard and login to get the version information. 

Please delete options that are not relevant.

- [ x ] I have performed a self-review of my code, adhering to established codebase patterns and conventions.