### PR TITLE
Add new LXC: SilverBullet

### DIFF
--- a/ct/silverbullet.sh
+++ b/ct/silverbullet.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: ewilazarus (Gabriel Lima)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+   _____ ______ _    ____________  ____  __  ____    __    ____________
+  / ___//  _/ /| |  / / ____/ __ \/ __ )/ / / / /   / /   / ____/_  __/
+  \__ \ / // / | | / / __/ / /_/ / __  / / / / /   / /   / __/   / /
+ ___/ // // /__| |/ / /___/ _, _/ /_/ / /_/ / /___/ /___/ /___  / /
+/____/___/_____/___/_____/_/ |_/_____/\____/_____/_____/_____/ /_/
+ 
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="SilverBullet"
+var_disk="2"
+var_cpu="1"
+var_ram="512"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -d /opt/silverbullet ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Stopping ${APP} Service"
+systemctl stop -q silverbullet
+msg_ok "Stopped ${APP} Service"
+
+msg_info "Updating ${APP}"
+silverbullet upgrade &> /dev/null
+msg_ok "Updated ${APP}"
+
+msg_info "Starting ${APP} Service"
+systemctl start -q silverbullet
+msg_ok "Started ${APP} Service"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+         ${BL}http://${IP}:3000${CL} \n"

--- a/install/silverbullet-install.sh
+++ b/install/silverbullet-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: ewilazarus (Gabriel Lima)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# This is the path of the directory where all the markdown notes will be stored.
+SB_NOTES_DIR="/opt/silverbullet/notes"
+
+# This is a helper function that will move binaries in the deno bin folder to /usr/bin.
+# It will also remove the `.deno` folder in the root directory to prevent cluttering.
+replace_deno_bin() {
+  mv /root/.deno/bin/$1 /usr/bin/$1
+  rm -rf /root/.deno
+}
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl unzip
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Deno"
+$STD bash <(curl -fsSL https://deno.land/install.sh)
+replace_deno_bin "deno"
+msg_ok "Installed Deno"
+
+msg_info "Installing SilverBullet"
+$STD deno install -f --name silverbullet --unstable-kv --unstable-worker-options -A https://get.silverbullet.md
+replace_deno_bin "silverbullet"
+mkdir -p $SB_NOTES_DIR
+msg_ok "Installed SilverBullet"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/silverbullet.service
+[Unit]
+Description=SilverBullet
+After=network.target
+
+[Service]
+User=root
+WorkingDirectory=$SB_NOTES_DIR
+SyslogIdentifier=silverbullet
+Restart=on-failure
+ExecStart=silverbullet -L 0.0.0.0 .
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now silverbullet
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"


### PR DESCRIPTION
## Description

If applied, this PR will add a new LXC for running [SilverBullet](https://github.com/silverbulletmd/silverbullet).

> SilverBullet is a note-taking application optimized for people with a [hacker mindset](https://en.wikipedia.org/wiki/Hacker). We all take notes. There’s a million note taking applications out there. [Literally](https://www.noteapps.ca/). Wouldn’t it be nice to have one where your notes are more than plain text files? Where your notes essentially become a database that you can query; that you can build custom knowledge applications on top of? A hackable notebook, if you will?

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
- [x] This change requires a documentation update

## Testing

The code has been tested by invoking 

```
bash -c "$(wget -qLO - https://github.com/ewilazarus/Proxmox/raw/silverbullet-test/ct/silverbullet.sh)"
```

Where `silverbullet-test` is a branch with [these minor differences](https://github.com/ewilazarus/Proxmox/compare/silverbullet..silverbullet-test).

## Screenshots

<img width="652" alt="image" src="https://github.com/tteck/Proxmox/assets/1023238/f29cd76e-f8e6-4fa0-8ab9-cef5804c2970">

![image](https://github.com/tteck/Proxmox/assets/1023238/ab838914-c783-4d95-9884-78bfa9dd3e69)

## Previous Attempts

- https://github.com/tteck/Proxmox/pull/3324

