### PR TITLE
fixes #3405 always set LC_ALL=C on update scripts

### DIFF
--- a/misc/update-lxcs-cron.sh
+++ b/misc/update-lxcs-cron.sh
@@ -5,6 +5,9 @@
 # License: MIT
 # https://github.com/tteck/Proxmox/raw/main/LICENSE
 
+LC_ALL=C
+export LC_ALL
+
 echo "$(date)"
 excluded_containers=("$@")
 function update_container() {

--- a/misc/update-lxcs.sh
+++ b/misc/update-lxcs.sh
@@ -5,6 +5,9 @@
 # License: MIT
 # https://github.com/tteck/Proxmox/raw/main/LICENSE
 
+LC_ALL=C
+export LC_ALL
+
 function header_info {
   clear
   cat <<"EOF"


### PR DESCRIPTION
## Description

Force LC_ALL=C in update scripts to avoid warnings and errors. 

Fixes #3405 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

