### PR TITLE
BunkerWeb - update repository address

### DIFF
--- a/install/bunkerweb-install.sh
+++ b/install/bunkerweb-install.sh
@@ -33,7 +33,7 @@ msg_ok "Installed Nginx"
 RELEASE=$(curl -s https://api.github.com/repos/bunkerity/bunkerweb/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 msg_info "Installing BunkerWeb v${RELEASE}"
 export UI_WIZARD=1
-curl -sSL https://packagecloud.io/install/repositories/bunkerity/bunkerweb/script.deb.sh | bash &>/dev/null
+curl -sSL https:/repo.bunkerweb.io/install/script.deb.sh | bash &>/dev/null
 $STD apt-get install -y bunkerweb=${RELEASE}
 cat <<EOF >/etc/apt/preferences.d/bunkerweb
 Package: bunkerweb


### PR DESCRIPTION
## Description

BunkerWeb repository address is now available at https://repo.bunkerweb.io

Source : https://docs.bunkerweb.io/latest/integrations/#linux

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.