### PR TITLE
Update gitea.sh

### DIFF
--- a/ct/gitea.sh
+++ b/ct/gitea.sh
@@ -62,6 +62,7 @@ wget -q https://github.com/go-gitea/gitea/releases/download/v$RELEASE/gitea-$REL
 systemctl stop gitea
 rm -rf /usr/local/bin/gitea 
 mv gitea* /usr/local/bin/gitea
+chmod +x /usr/local/bin/gitea
 systemctl start gitea
 msg_ok "Updated $APP Successfully"
 exit


### PR DESCRIPTION
## Description
Fix permissions according to the [Gitea documentation](https://docs.gitea.com/installation/install-from-binary).

## Issue
My own issue: I had Gitea installed previously and I use the user "git" for it. After using the update script, it wouldn't launch, so I had to update the permissions of the Gitea binary.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
