### PR TITLE
Update traefik-install.sh to select latest stable version

### DIFF
--- a/install/traefik-install.sh
+++ b/install/traefik-install.sh
@@ -21,7 +21,7 @@ $STD apt-get install -y gpg
 $STD apt-get install -y apt-transport-https
 msg_ok "Installed Dependencies"
 
-RELEASE=3.0.4 #$(curl -s https://api.github.com/repos/traefik/traefik/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+RELEASE=$(curl -s https://api.github.com/repos/traefik/traefik/releases | grep -oP '"tag_name":\s*"v\K[\d.]+?(?=")' | sort -V | tail -n 1)
 msg_info "Installing Traefik v${RELEASE}"
 mkdir -p /etc/traefik/{conf.d,ssl}
 wget -q https://github.com/traefik/traefik/releases/download/v${RELEASE}/traefik_v${RELEASE}_linux_amd64.tar.gz


### PR DESCRIPTION
## Description

It updates the script used to fetch the latest Traefik release to ensure that only stable versions (without pre-release tags such as RC, beta, etc.) are selected. It now fetches the list of latest releases, filters out any tags containing a dash (indicating pre-release versions), sorts the remaining tags, and selects the highest version number.

Fixes #3294

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
