### PR TITLE
Allow octoprint user to perform system functions

### DIFF
--- a/install/octoprint-install.sh
+++ b/install/octoprint-install.sh
@@ -37,6 +37,7 @@ msg_info "Creating user octoprint"
 useradd -m -s /bin/bash -p $(openssl passwd -1 octoprint) octoprint
 usermod -aG sudo,tty,dialout octoprint
 chown -R octoprint:octoprint /opt
+echo "octoprint ALL=NOPASSWD: $(command -v systemctl) restart octoprint, $(command -v reboot), $(command -v poweroff)" > /etc/sudoers.d/octoprint
 msg_ok "Created user octoprint"
 
 msg_info "Installing OctoPrint"


### PR DESCRIPTION
#### _I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request._
Kindly noted and acknowledged

## Description
This line concatenates the octoprint user to the `sudoers` file, specifically for the `systemctl`, `reboot` and `shutdown` commands. This is consistent with the methodology used in the [octopi source on Raspbian](https://github.com/guysoft/OctoPi/blob/fb7093bfb950dc890323a4607068e8ceb5fa36cd/src/modules/octopi/start_chroot_script).
Required in order to use the commands under `Settings > Octoprint > Server > Commands`. For version 1.10.2, note that those commands are typically as follows, respectively:
![image](https://github.com/user-attachments/assets/87c7276d-8c4b-4df2-9406-9dfc82615bf1)

## Type of change
Modification to an install script (octoprint.sh) to enable some of the application's features.

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.