### PR TITLE
Add Scrutiny scripts

### DIFF
--- a/ct/scrutiny.sh
+++ b/ct/scrutiny.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/remz1337/Proxmox/remz/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # Co-Author: remz1337

--- a/ct/scrutiny.sh
+++ b/ct/scrutiny.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/remz1337/Proxmox/remz/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: remz1337
+# License: MIT
+# https://github.com/remz1337/Proxmox/raw/main/LICENSE
+
+function header_info {
+  clear
+  cat <<"EOF"
+   _____                 __  _            
+  / ___/____________  __/ /_(_)___  __  __
+  \__ \/ ___/ ___/ / / / __/ / __ \/ / / /
+ ___/ / /__/ /  / /_/ / /_/ / / / / /_/ / 
+/____/\___/_/   \__,_/\__/_/_/ /_/\__, /  
+                                 /____/   
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Scrutiny"
+var_disk="4"
+var_cpu="2"
+var_ram="512"
+var_os="debian"
+var_version="11"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+  if [[ ! -f /etc/systemd/system/scrutiny.service ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Stopping Scrutiny"
+  systemctl stop scrutiny.service
+  msg_ok "Stopped Scrutiny"
+
+  msg_info "Updating Scrutiny"
+  cd /opt/scrutiny/bin
+  rm -rf scrutiny-web-linux-amd64
+  wget "https://github.com/AnalogJ/scrutiny/releases/latest/download/scrutiny-web-linux-amd64"
+  chmod +x scrutiny-web-linux-amd64
+
+  cd /opt/scrutiny/web
+  rm -rf /opt/scrutiny/web/*
+  wget "https://github.com/AnalogJ/scrutiny/releases/latest/download/scrutiny-web-frontend.tar.gz"
+  tar xvzf scrutiny-web-frontend.tar.gz --strip-components 1 -C .
+  msg_ok "Updated Scrutiny"
+
+  msg_info "Starting Scrutiny"
+  systemctl start scrutiny.service
+  msg_ok "Started Scrutiny"
+}
+
+install_collector() {
+  #header_info
+  if [[ ! -f /etc/systemd/system/scrutiny.service ]]; then
+    #Not found, install
+	msg_info "Installing Scrutiny Collector"
+    apt-get install -y smartmontools &>/dev/null
+    mkdir -p /opt/scrutiny/bin
+    mkdir -p /opt/scrutiny/config
+  
+    cd /opt/scrutiny/config
+    wget -O collector.yaml https://raw.githubusercontent.com/AnalogJ/scrutiny/master/example.collector.yaml &>/dev/null
+    # #Enable API endpoint
+    cat <<EOF >>/opt/scrutiny/config/collector.yaml
+api:
+  endpoint: 'http://${IP}:8080'
+EOF
+
+    cd /opt/scrutiny/bin
+    wget "https://github.com/AnalogJ/scrutiny/releases/latest/download/scrutiny-collector-metrics-linux-amd64" &>/dev/null
+    chmod +x scrutiny-collector-metrics-linux-amd64
+
+    cat <<EOF >/etc/systemd/system/scrutiny.service
+[Unit]
+Description="Scrutiny Collector service"
+Requires=scrutiny.timer
+After=syslog.target network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/scrutiny
+ExecStart=/opt/scrutiny/bin/scrutiny-collector-metrics-linux-amd64 run --config /opt/scrutiny/config/collector.yaml
+EOF
+
+    cat <<EOF >/etc/systemd/system/scrutiny.timer
+[Unit]
+Description="Timer for the scrutiny.service"
+
+[Timer]
+Unit=scrutiny.service
+OnCalendar=*:0/15
+
+[Install]
+WantedBy=timers.target
+EOF
+
+    systemctl enable -q --now scrutiny.timer
+	msg_ok "Installed Scrutiny Collector"
+	msg_ok "Don't forget to update the the configuration in ${GN}/opt/scrutiny/config/collector.yaml${CL}"
+  else
+    #Already installed, update
+	msg_ok "Scrutiny Collector already installed. It will be updated."
+    msg_info "Stopping Scrutiny Collector"
+    systemctl disable -q --now scrutiny.timer
+    msg_ok "Stopped Scrutiny Collector"
+
+    msg_info "Updating Scrutiny Collector"
+    cd /opt/scrutiny/bin
+    rm -rf scrutiny-collector-metrics-linux-amd64 &>/dev/null
+    wget "https://github.com/AnalogJ/scrutiny/releases/latest/download/scrutiny-collector-metrics-linux-amd64" &>/dev/null
+    chmod +x scrutiny-collector-metrics-linux-amd64
+    msg_ok "Updated Scrutiny Collector"
+
+    msg_info "Starting Scrutiny Collector"
+    systemctl enable -q --now scrutiny.timer
+    msg_ok "Started Scrutiny Collector"
+  fi
+}
+
+start
+build_container
+description
+
+msg_info "Setting Container to Normal Resources"
+pct set $CTID -memory 256
+pct set $CTID -cores 1
+msg_ok "Set Container to Normal Resources"
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+         ${BL}http://${IP}:8080${CL} \n"
+		 
+		 
+#header_info
+echo -e "\nDo you wish to install/update Scrutiny Collector?\n"
+while true; do
+  read -p "Start the Scrutiny Collector Install/Update Script (y/n)?" yn
+  case $yn in
+  [Yy]*) break ;;
+  [Nn]*) exit ;;
+  *) echo "Please answer yes or no." ;;
+  esac
+done
+
+install_collector

--- a/install/scrutiny-install.sh
+++ b/install/scrutiny-install.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: remz1337
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies (Patience)"
+$STD apt-get install -y {curl,sudo,mc,libc6}
+msg_ok "Installed Dependencies"
+
+if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "INFLUXDB v2" --yesno "Scrutiny needs InfluxDB. Do you wish to install a new InfluxDB in the same LXC?" 10 58); then
+  msg_info "Installing InfluxDB Dependencies"
+  $STD apt-get install -y lsb-base
+  $STD apt-get install -y lsb-release
+  $STD apt-get install -y gnupg2
+  msg_ok "Installed InfluxDB Dependencies"
+
+  msg_info "Setting up InfluxDB Repository"
+  wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+  cat influxdata-archive_compat.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+  sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main" > /etc/apt/sources.list.d/influxdata.list'
+  msg_ok "Set up InfluxDB Repository"
+
+  msg_info "Installing InfluxDB"
+  $STD apt-get update
+  $STD apt-get install -y influxdb2
+  $STD systemctl enable --now influxdb
+  msg_ok "Installed InfluxDB"
+else
+  echo -e "${YW}Don't forget to update the scrutiny configuration file with the external InfluxDB parameters.${CL}"
+fi
+
+msg_info "Installing Scrutiny (web app and API)"
+mkdir -p /opt/scrutiny/config
+mkdir -p /opt/scrutiny/web
+mkdir -p /opt/scrutiny/bin
+
+cd /opt/scrutiny/config
+$STD wget -O scrutiny.yaml https://raw.githubusercontent.com/AnalogJ/scrutiny/master/example.scrutiny.yaml
+
+cd /opt/scrutiny/bin
+$STD wget "https://github.com/AnalogJ/scrutiny/releases/latest/download/scrutiny-web-linux-amd64"
+chmod +x scrutiny-web-linux-amd64
+
+cd /opt/scrutiny/web
+$STD wget "https://github.com/AnalogJ/scrutiny/releases/latest/download/scrutiny-web-frontend.tar.gz"
+
+# Next, lets extract the frontend files.
+# NOTE: after extraction, there **should not** be a `dist` subdirectory in `/opt/scrutiny/web` directory.
+$STD tar xvzf scrutiny-web-frontend.tar.gz --strip-components 1 -C .
+msg_ok "Installed Scrutiny"
+
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/scrutiny.service
+[Unit]
+Description=Scrutiny service
+After=syslog.target network.target
+
+[Service]
+#SuccessExitStatus=143
+#User=root
+#Group=root
+
+Type=simple
+
+WorkingDirectory=/opt/scrutiny
+ExecStart=/opt/scrutiny/bin/scrutiny-web-linux-amd64 start --config /opt/scrutiny/config/scrutiny.yaml
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now scrutiny
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+rm -rf /opt/scrutiny/web/scrutiny-web-frontend.tar.gz
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"
+
+echo -e "Don't forget to update the Scrutiny config file (${GN}/opt/scrutiny/config/scrutiny.yaml${CL}) and reboot."


### PR DESCRIPTION
## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

These scripts add support for Scrutiny
https://github.com/AnalogJ/scrutiny

Opened as draft as I would like your feedback on the approach of the script.

It will create a new LXC containing only the webapp AND install the collector on the host (need acces to disk controllers to read metrics).

User need to update both the webapp and collector config files (`/opt/scrutiny/config` in LXC and on the host).

It does not install an InfluxDB, thus someone that would want to use Scrutiny will need to setup a separate InfluxDB LXC (or install manually inside the same LXC). I feel like this should be documented somewhere.

## Type of change

- [X] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
