### PR TITLE
BunkerWeb - use repo.bunkerweb.io instead of packagecloud.io (new address is fixed !)

### DIFF
--- a/install/bunkerweb-install.sh
+++ b/install/bunkerweb-install.sh
@@ -31,10 +31,8 @@ msg_ok "Installed Nginx"
 
 RELEASE=$(curl -s https://api.github.com/repos/bunkerity/bunkerweb/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 msg_info "Installing BunkerWeb v${RELEASE} (Patience)"
-#curl -fsSL "https://repo.bunkerweb.io/bunkerity/bunkerweb/gpgkey" | gpg --dearmor >/etc/apt/keyrings/bunkerity_bunkerweb-archive-keyring.gpg
-#echo "deb [signed-by=/etc/apt/keyrings/bunkerity_bunkerweb-archive-keyring.gpg] https://repo.bunkerweb.io/bunkerity/bunkerweb/debian/ bookworm main" >/etc/apt/sources.list.d/bunkerity_bunkerweb.list
-curl -fsSL "https://packagecloud.io/bunkerity/bunkerweb/gpgkey" | gpg --dearmor >/etc/apt/keyrings/bunkerity_bunkerweb-archive-keyring.gpg
-echo "deb [signed-by=/etc/apt/keyrings/bunkerity_bunkerweb-archive-keyring.gpg] https://packagecloud.io/bunkerity/bunkerweb/debian/ bookworm main" >/etc/apt/sources.list.d/bunkerity_bunkerweb.list
+curl -fsSL "https://repo.bunkerweb.io/bunkerity/bunkerweb/gpgkey" | gpg --dearmor >/etc/apt/keyrings/bunkerity_bunkerweb-archive-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/bunkerity_bunkerweb-archive-keyring.gpg] https://repo.bunkerweb.io/bunkerity/bunkerweb/debian/ bookworm main" >/etc/apt/sources.list.d/bunkerity_bunkerweb.list
 $STD apt-get update
 export UI_WIZARD=1
 $STD apt-get install -y bunkerweb=${RELEASE}


### PR DESCRIPTION
## Description

We have fixed the issues with our repository at repo.bunkerweb.io, you can now use the new address.

Sorry for the incovenience @tteck and thanks for your work !

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
