### PR TITLE
Update gitea.sh - Allow git clone over SSH by default

### DIFF
--- a/install/gitea-install.sh
+++ b/install/gitea-install.sh
@@ -27,12 +27,13 @@ RELEASE=$(wget -q https://github.com/go-gitea/gitea/releases/latest -O - | grep 
 wget -q https://github.com/go-gitea/gitea/releases/download/v$RELEASE/gitea-$RELEASE-linux-amd64
 mv gitea* /usr/local/bin/gitea
 chmod +x /usr/local/bin/gitea
-adduser --system --group --disabled-password --home /etc/gitea gitea > /dev/null
+adduser --system --group --disabled-password --shell /bin/bash --home /etc/gitea gitea > /dev/null
 mkdir -p /var/lib/gitea/{custom,data,log}
 chown -R gitea:gitea /var/lib/gitea/
 chmod -R 750 /var/lib/gitea/
 chown root:gitea /etc/gitea
 chmod 770 /etc/gitea
+sudo -u gitea ln -s /var/lib/gitea/data/.ssh/ /etc/gitea/.ssh
 msg_ok "Installed Gitea"
 
 msg_info "Creating Service"


### PR DESCRIPTION
## Description

The current installation of gitea is done in such a way that a `git clone` over ssh is not possible. I expected this to be enabled by default and went down a rabbit hole figuring out why it did not work.
Depending on your perspective this is arguably a bug fix or a new feature but it should be non-breaking regardless.

You can currently reproduce this issue by:
* install gitea from current script (to be specific I did a Deb 12 unprivileged install) 
* initialise a test repo
* add an ssh key to a user account: (User) Settings > SSH / GPG Keys > Add Key
* attempt a git clone over ssh: `git clone gitea@<host>:<user>/test.git`
    * you will get a password prompt for the gitea user. the ssh key obviously has not worked and the user password also fails to work (as expected).

After this fix:
* install gitea from the script
* initialise a test repo
* add an ssh key to a user account: (User) Settings > SSH / GPG Keys > Add Key
* attempt a git clone over ssh: `git clone gitea@<host>:<user>/test.git`
    * the git clone over ssh should successfully authenticate and clone the repo. (as well as allow other actions - fetch, push, etc)

## The change
There was two issues I identified with the current script.
1. The gitea user added during install does not have a shell assigned. This appears to be contrary to the [official instructions](https://docs.gitea.com/installation/install-from-binary#prepare-environment) that specify /bin/bash for the gitea user.
2. When authenticating over ssh the openssh binary will look for the `authorized_keys` file in the home user of the account authenticating. Specifically, per the current script that it will look for `/etc/gitea/.ssh/authorized_keys` but the gitea app stores the actual `authorized_keys` file under the application data directory at `/var/lib/gitea/data/.ssh/authorized_keys`. By symlinking the home directory of the gitea user to gitea app data directory openssh can find the `authorized_keys` file and authenticate the user who is trying to git clone.

The two lines changed in this pull request correspond to the two issues explained above.

There is almost certainly alternate ways to fix this problem but this was the quickets and easiest way I identified. Obviously accept, reject or modify these changes as you see fit. Thanks for your work!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
