### PR TITLE
Update plex-install.sh

### DIFF
--- a/install/plex-install.sh
+++ b/install/plex-install.sh
@@ -17,6 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
+$STD apt-get install -y gpg
 msg_ok "Installed Dependencies"
 
 msg_info "Setting Up Hardware Acceleration"


### PR DESCRIPTION
## Description

Add gpg dependency which is needed to avoid warning when using plexupdate.sh

You can currently reproduce this issue by:

* Executing the installation script inside de LXC console
* Running update manually:

```
/opt/plexupdate/plexupdate.sh -f
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)