### PR TITLE
Update wireguard-install.sh adding `resolvconf`

### DIFF
--- a/install/wireguard-install.sh
+++ b/install/wireguard-install.sh
@@ -21,7 +21,7 @@ $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
 msg_info "Installing WireGuard"
-$STD apt-get install -y wireguard wireguard-tools net-tools iptables
+$STD apt-get install -y wireguard wireguard-tools net-tools iptables resolvconf
 iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" install -y iptables-persistent &>/dev/null
 $STD netfilter-persistent reload


### PR DESCRIPTION
Add `resolvconf` package to `wireguard-install.sh` for essential DNS resolution

Including the `resolvconf` package is crucial for ensuring that clients can resolve DNS queries and access the internet. Without this package, the connection will fail to load.

---

## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

Please include a summary of the change and/or which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New Script (Develop a new script or set of scripts that are fully functional and thoroughly tested)
- [ ] I have performed a self-review of my code, adhering to established codebase patterns and conventions.
- [ ] This change requires a documentation update
