### PR TITLE
Add openSUSE support to LXC update scripts

### DIFF
--- a/misc/update-lxcs-cron.sh
+++ b/misc/update-lxcs-cron.sh
@@ -17,6 +17,7 @@ function update_container() {
   archlinux) pct exec "$container" -- bash -c "pacman -Syyu --noconfirm" ;;
   fedora | rocky | centos | alma) pct exec "$container" -- bash -c "dnf -y update && dnf -y upgrade" ;;
   ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" dist-upgrade -y; rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED" ;;
+  opensuse) pct exec "$container" -- bash -c "zypper ref && zypper --non-interactive dup" ;;
   esac
 }
 

--- a/misc/update-lxcs.sh
+++ b/misc/update-lxcs.sh
@@ -68,6 +68,7 @@ function update_container() {
   archlinux) pct exec "$container" -- bash -c "pacman -Syyu --noconfirm" ;;
   fedora | rocky | centos | alma) pct exec "$container" -- bash -c "dnf -y update && dnf -y upgrade" ;;
   ubuntu | debian | devuan) pct exec "$container" -- bash -c "apt-get update 2>/dev/null | grep 'packages.*upgraded'; apt list --upgradable && apt-get -yq dist-upgrade 2>&1; rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED" ;;
+  opensuse) pct exec "$container" -- bash -c "zypper ref && zypper --non-interactive dup" ;;
   esac
 }
 


### PR DESCRIPTION
## Description

This adds support for updating openSUSE LXCs via zypper.

## Type of change

Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Documentation update required (this change requires an update to the documentation)

