### PR TITLE
Tweak for Zipline

### DIFF
--- a/install/zipline-install.sh
+++ b/install/zipline-install.sh
@@ -39,8 +39,8 @@ msg_ok "Installed Node.js"
 msg_info "Setting up PostgreSQL"
 DB_NAME=ziplinedb
 DB_USER=zipline
-DB_PASS="$(openssl rand -base64 18 | cut -c1-13)"
-SECRET_KEY="$(openssl rand -base64 32 | cut -c1-24)"
+DB_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"
+SECRET_KEY="$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"
 $STD sudo -u postgres psql -c "CREATE ROLE $DB_USER WITH LOGIN PASSWORD '$DB_PASS';"
 $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER ENCODING 'UTF8' TEMPLATE template0;"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET client_encoding TO 'utf8';"


### PR DESCRIPTION

## Description
https://github.com/tteck/Proxmox/discussions/2089#discussioncomment-10738447

Zipline is sensitiv with special characters. I switch the Pass-Generation to normal Characters. 
I have done 5 installations on my local site before, I never had the “luck” to get special characters in the generated key, but it seems this happened sporadically with some users & Zipline reacts badly to it.

## Type of change

- [x] Bug fix (non-breaking change that resolves an issue)

Old: 
DB_PASS="$(openssl rand -base64 18 | cut -c1-13)"
SECRET_KEY="$(openssl rand -base64 32 | cut -c1-24)"

New:
DB_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"
SECRET_KEY="$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"

