### PR TITLE
Add new LXC: MySQL

### DIFF
--- a/ct/mysql.sh
+++ b/ct/mysql.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: MickLesk (Canbiz)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+    __  ___      _____ ____    __ 
+   /  |/  /_  __/ ___// __ \  / / 
+  / /|_/ / / / /\__ \/ / / / / /  
+ / /  / / /_/ /___/ / /_/ / / /___
+/_/  /_/\__, //____/\___\_\/_____/
+       /____/                     
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="MySQL"
+var_disk="4"
+var_cpu="1"
+var_ram="1024"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -f /usr/share/keyrings/mysql.gpg ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Updating ${APP} LXC"
+apt-get update &>/dev/null
+apt-get -y upgrade &>/dev/null
+msg_ok "Updated Successfully"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} setup completed successfully with the IP:\n\
+${IP}\n\
+If you use phpMyAdmin, you can access it at the following URL:\n\
+${BL}http://${IP}/phpMyAdmin${CL}\n"

--- a/ct/mysql.sh
+++ b/ct/mysql.sh
@@ -68,7 +68,3 @@ build_container
 description
 
 msg_ok "Completed Successfully!\n"
-echo -e "${APP} setup completed successfully with the IP:\n\
-${IP}\n\
-If you use phpMyAdmin, you can access it at the following URL:\n\
-${BL}http://${IP}/phpMyAdmin${CL}\n"

--- a/install/mysql-install.sh
+++ b/install/mysql-install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: MickLesk (Canbiz)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+# Source: https://www.mysql.com/products/community | https://www.phpmyadmin.net
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  sudo \
+  lsb-release \
+  curl \
+  gnupg   \
+  apt-transport-https \
+  make \
+  mc
+msg_ok "Installed Dependencies"
+
+msg_info "Installing MySQL"
+curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 | gpg --dearmor  -o /usr/share/keyrings/mysql.gpg
+echo "deb [signed-by=/usr/share/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian $(lsb_release -sc) mysql-8.0" >/etc/apt/sources.list.d/mysql.list
+$STD sudo apt update
+export DEBIAN_FRONTEND=noninteractive
+$STD apt-get install -y \
+  mysql-common \
+  mysql-community-client \
+  mysql-community-server
+msg_ok "Installed MySQL"
+
+msg_info "Configure MySQL Server"
+ADMIN_PASS="$(openssl rand -base64 18 | cut -c1-13)"
+$STD sudo mysql -uroot -p"$ADMIN_PASS" -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$ADMIN_PASS'; FLUSH PRIVILEGES;"
+echo "" >>~/mysql.creds
+echo -e "MySQL Root Password: $ADMIN_PASS" >>~/mysql.creds
+msg_ok "MySQL Server configured"
+
+read -r -p "Would you like to add PhpMyAdmin? <y/N> " prompt
+if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  msg_info "Adding phpMyAdmin"
+  $STD apt-get install -y \
+    apache2 \
+    php \
+    php-mysqli \
+    php-mbstring \
+    php-zip \
+    php-gd \
+    php-json \
+    php-curl 
+	
+	wget -q "https://files.phpmyadmin.net/phpMyAdmin/5.2.1/phpMyAdmin-5.2.1-all-languages.tar.gz"
+	sudo mkdir -p /var/www/html/phpMyAdmin
+	$STD sudo tar xvf phpMyAdmin-5.2.1-all-languages.tar.gz --strip-components=1 -C /var/www/html/phpMyAdmin
+	sudo cp /var/www/html/phpMyAdmin/config.sample.inc.php /var/www/html/phpMyAdmin/config.inc.php
+	SECRET=$(openssl rand -base64 32)
+	sudo sed -i "s#\$cfg\['blowfish_secret'\] = '';#\$cfg['blowfish_secret'] = '${SECRET}';#" /var/www/html/phpMyAdmin/config.inc.php
+	sudo chmod 660 /var/www/html/phpMyAdmin/config.inc.php
+	sudo chown -R www-data:www-data /var/www/html/phpMyAdmin
+	sudo systemctl restart apache2
+  msg_ok "Added phpMyAdmin"
+fi
+
+msg_info "Start Service"
+sudo systemctl enable -q --now mysql
+msg_ok "Service started"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/install/mysql-install.sh
+++ b/install/mysql-install.sh
@@ -29,7 +29,7 @@ msg_ok "Installed Dependencies"
 msg_info "Installing MySQL"
 curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 | gpg --dearmor  -o /usr/share/keyrings/mysql.gpg
 echo "deb [signed-by=/usr/share/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian $(lsb_release -sc) mysql-8.0" >/etc/apt/sources.list.d/mysql.list
-$STD sudo apt update
+$STD apt-get update
 export DEBIAN_FRONTEND=noninteractive
 $STD apt-get install -y \
   mysql-common \
@@ -39,7 +39,7 @@ msg_ok "Installed MySQL"
 
 msg_info "Configure MySQL Server"
 ADMIN_PASS="$(openssl rand -base64 18 | cut -c1-13)"
-$STD sudo mysql -uroot -p"$ADMIN_PASS" -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$ADMIN_PASS'; FLUSH PRIVILEGES;"
+$STD mysql -uroot -p"$ADMIN_PASS" -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$ADMIN_PASS'; FLUSH PRIVILEGES;"
 echo "" >>~/mysql.creds
 echo -e "MySQL Root Password: $ADMIN_PASS" >>~/mysql.creds
 msg_ok "MySQL Server configured"
@@ -58,19 +58,19 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
     php-curl 
 	
 	wget -q "https://files.phpmyadmin.net/phpMyAdmin/5.2.1/phpMyAdmin-5.2.1-all-languages.tar.gz"
-	sudo mkdir -p /var/www/html/phpMyAdmin
-	$STD sudo tar xvf phpMyAdmin-5.2.1-all-languages.tar.gz --strip-components=1 -C /var/www/html/phpMyAdmin
-	sudo cp /var/www/html/phpMyAdmin/config.sample.inc.php /var/www/html/phpMyAdmin/config.inc.php
+	mkdir -p /var/www/html/phpMyAdmin
+	$STD tar xvf phpMyAdmin-5.2.1-all-languages.tar.gz --strip-components=1 -C /var/www/html/phpMyAdmin
+	cp /var/www/html/phpMyAdmin/config.sample.inc.php /var/www/html/phpMyAdmin/config.inc.php
 	SECRET=$(openssl rand -base64 32)
-	sudo sed -i "s#\$cfg\['blowfish_secret'\] = '';#\$cfg['blowfish_secret'] = '${SECRET}';#" /var/www/html/phpMyAdmin/config.inc.php
-	sudo chmod 660 /var/www/html/phpMyAdmin/config.inc.php
-	sudo chown -R www-data:www-data /var/www/html/phpMyAdmin
-	sudo systemctl restart apache2
+	sed -i "s#\$cfg\['blowfish_secret'\] = '';#\$cfg['blowfish_secret'] = '${SECRET}';#" /var/www/html/phpMyAdmin/config.inc.php
+	chmod 660 /var/www/html/phpMyAdmin/config.inc.php
+	chown -R www-data:www-data /var/www/html/phpMyAdmin
+	systemctl restart apache2
   msg_ok "Added phpMyAdmin"
 fi
 
 msg_info "Start Service"
-sudo systemctl enable -q --now mysql
+systemctl enable -q --now mysql
 msg_ok "Service started"
 
 motd_ssh


### PR DESCRIPTION
## Description
https://github.com/tteck/Proxmox/discussions/3449#discussioncomment-10882198
Yesterday, ive prepared an MySQL LXC, today i finished it.

Is it still possible to contribute at all? 
Referring to your post from yesterday (https://github.com/tteck/Proxmox/discussions/3867), it sounded like you were no longer accepting contributions from other people. 

I still have 3-4 LXC that I wanted to complete in the next few weeks, so the general question is it still welcome?


There is the possibility to add phpMyAdmin, because I think it makes sense. (perhaps also useful for MariaDB?)

The login (master) password can be found in ~/mysql.creds.
This applies to both MySQL and phpMyAdmin. 
(Login: root | password) 

![image](https://github.com/user-attachments/assets/330cabb0-c7fe-4c7a-9549-edbdecd8b45c)

- [x] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)

