### PR TITLE
[Breaking Change]: Optional Installing of phpMyAdmin for MariaDB

### DIFF
--- a/install/mariadb-install.sh
+++ b/install/mariadb-install.sh
@@ -40,7 +40,7 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
 	
 	wget -q "https://files.phpmyadmin.net/phpMyAdmin/5.2.1/phpMyAdmin-5.2.1-all-languages.tar.gz"
 	mkdir -p /var/www/html/phpMyAdmin
-	$STD tar xvf phpMyAdmin-5.2.1-all-languages.tar.gz --strip-components=1 -C /var/www/html/phpMyAdmin
+	tar xf phpMyAdmin-5.2.1-all-languages.tar.gz --strip-components=1 -C /var/www/html/phpMyAdmin
 	cp /var/www/html/phpMyAdmin/config.sample.inc.php /var/www/html/phpMyAdmin/config.inc.php
 	SECRET=$(openssl rand -base64 24)
 	sed -i "s#\$cfg\['blowfish_secret'\] = '';#\$cfg['blowfish_secret'] = '${SECRET}';#" /var/www/html/phpMyAdmin/config.inc.php

--- a/install/mariadb-install.sh
+++ b/install/mariadb-install.sh
@@ -25,6 +25,31 @@ sed -i 's/^# *\(port *=.*\)/\1/' /etc/mysql/my.cnf
 sed -i 's/^bind-address/#bind-address/g' /etc/mysql/mariadb.conf.d/50-server.cnf
 msg_ok "Installed MariaDB"
 
+read -r -p "Would you like to add PhpMyAdmin? <y/N> " prompt
+if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  msg_info "Installing phpMyAdmin"
+  $STD apt-get install -y \
+    apache2 \
+    php \
+    php-mysqli \
+    php-mbstring \
+    php-zip \
+    php-gd \
+    php-json \
+    php-curl 
+	
+	wget -q "https://files.phpmyadmin.net/phpMyAdmin/5.2.1/phpMyAdmin-5.2.1-all-languages.tar.gz"
+	mkdir -p /var/www/html/phpMyAdmin
+	$STD tar xvf phpMyAdmin-5.2.1-all-languages.tar.gz --strip-components=1 -C /var/www/html/phpMyAdmin
+	cp /var/www/html/phpMyAdmin/config.sample.inc.php /var/www/html/phpMyAdmin/config.inc.php
+	SECRET=$(openssl rand -base64 24)
+	sed -i "s#\$cfg\['blowfish_secret'\] = '';#\$cfg['blowfish_secret'] = '${SECRET}';#" /var/www/html/phpMyAdmin/config.inc.php
+	chmod 660 /var/www/html/phpMyAdmin/config.inc.php
+	chown -R www-data:www-data /var/www/html/phpMyAdmin
+	systemctl restart apache2
+  msg_ok "Installed phpMyAdmin"
+fi
+
 motd_ssh
 customize
 


### PR DESCRIPTION
## Description
I think it is a good addition to optionally offer the installation of phpMyAdmin with MariaDB as well. The user does not have to use it, but it works that way. :-)

![image](https://github.com/user-attachments/assets/790ef128-f9d9-41a7-b829-906e6de8855c)


## Type of change
- [x] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)

