### PR TITLE
Add new LXC: evcc

### DIFF
--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -55,8 +55,8 @@ function update_script() {
 header_info
 if [[ ! -f /etc/apt/sources.list.d/evcc-stable.list ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
 msg_info "Updating ${APP} LXC"
-apt-get update &>/dev/null
-apt-get install -y evcc &>/dev/null
+apt update &>/dev/null
+apt install -y evcc &>/dev/null
 msg_ok "Updated Successfully"
 exit
 }

--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -54,7 +54,7 @@ function default_settings() {
 function update_script() {
 header_info
 if [[ ! -f /etc/apt/sources.list.d/evcc-stable.list ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-msg_info "Updating ${APP} LXC"
+msg_info "Updating evcc LXC"
 apt update &>/dev/null
 apt install -y evcc &>/dev/null
 msg_ok "Updated Successfully"

--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -53,33 +53,11 @@ function default_settings() {
 
 function update_script() {
 header_info
-if [[ ! -d /usr/bin/evcc ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
-  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
-  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
-fi
-RELEASE=$(curl -s https://api.github.com/repos/evcc-io/evcc/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-4) }')
-if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
-  msg_info "Stopping ${APP}"
-  systemctl stop evcc
-  msg_ok "${APP} Stopped"
-  
-  msg_info "Updating ${APP} to ${RELEASE}"
-  wget -q "https://github.com/evcc-io/evcc/releases/download/${RELEASE}/evcc_${RELEASE}_amd64.deb"
-  $STD dpkg -i evcc_${RELEASE}_amd64.deb
-  msg_ok "Updated Successfully"
-  
-  msg_info "Starting ${APP}"
-  systemctl start evcc
-  msg_ok "Started ${APP}"
-  
-  msg_info "Cleaning Up"
-  rm -rf evcc_${RELEASE}_amd64.deb
-  msg_ok "Cleaned"
-  msg_ok "Updated Successfully"
-else
-  msg_ok "No update required. ${APP} is already at ${RELEASE}"
-fi
+if [[ ! -f /etc/apt/sources.list.d/evcc-stable.list ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Updating ${APP} LXC"
+apt-get update &>/dev/null
+apt-get install -y evcc &>/dev/null
+msg_ok "Updated Successfully"
 exit
 }
 

--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: MickLesk (Canbiz)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"     
+  ___ _   ____________
+ / _ \ | / / ___/ ___/
+/  __/ |/ / /__/ /__  
+\___/|___/\___/\___/  
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="evcc"
+var_disk="4"
+var_cpu="1"
+var_ram="1024"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -d /usr/bin/evcc ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
+fi
+RELEASE=$(curl -s https://api.github.com/repos/evcc-io/evcc/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-4) }')
+if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+  msg_info "Stopping ${APP}"
+  systemctl stop evcc
+  msg_ok "${APP} Stopped"
+  
+  msg_info "Updating ${APP} to ${RELEASE}"
+  wget -q "https://github.com/evcc-io/evcc/releases/download/${RELEASE}/evcc_${RELEASE}_amd64.deb"
+  $STD dpkg -i evcc_${RELEASE}_amd64.deb
+  msg_ok "Updated Successfully"
+  
+  msg_info "Starting ${APP}"
+  systemctl start evcc
+  msg_ok "Started ${APP}"
+  
+  msg_info "Cleaning Up"
+  rm -rf evcc_${RELEASE}_amd64.deb
+  msg_ok "Cleaned"
+  msg_ok "Updated Successfully"
+else
+  msg_ok "No update required. ${APP} is already at ${RELEASE}"
+fi
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} Setup should be reachable by going to the following URL.
+         ${BL}http://${IP}:7070${CL} \n"

--- a/install/evcc-install.sh
+++ b/install/evcc-install.sh
@@ -32,7 +32,7 @@ msg_ok "evcc Repository setup sucessfully"
 
 msg_info "Installing evcc"
 $STD apt install -y evcc
-systemctl enable --now evcc.service
+systemctl enable -q --now evcc.service
 msg_ok "Installed evcc"
 
 motd_ssh

--- a/install/evcc-install.sh
+++ b/install/evcc-install.sh
@@ -30,9 +30,12 @@ msg_ok "Installed Dependencies"
 msg_info "Setting up evcc Repository"
 curl -fsSL https://dl.evcc.io/public/evcc/stable/gpg.EAD5D0E07B0EC0FD.key | gpg --dearmor -o /etc/apt/keyrings/evcc-stable.gpg || msg_error "Failed to download GPG key"
 echo "deb [signed-by=/etc/apt/keyrings/evcc-stable.gpg] https://dl.evcc.io/public/evcc/stable/deb/debian $(lsb_release -cs) main" >/etc/apt/sources.list.d/evcc-stable.list || msg_error "Failed to add EVCC repository"
+$STD sudo apt update
+msg_ok "evcc Repository setup sucessfully"
 
 msg_info "Installing ${APPLICATION}"
 $STD sudo apt install -y evcc
+$STD systemctl enable --now evcc.service
 msg_ok "Installed ${APPLICATION}"
 
 motd_ssh

--- a/install/evcc-install.sh
+++ b/install/evcc-install.sh
@@ -20,22 +20,19 @@ $STD apt-get install -y \
   curl \
   sudo \
   mc \
-  debian-keyring \
-  debian-archive-keyring \
   lsb-release \
-  gpg \
-  apt-transport-https
+  gpg 
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up evcc Repository"
-curl -fsSL https://dl.evcc.io/public/evcc/stable/gpg.EAD5D0E07B0EC0FD.key | gpg --dearmor -o /etc/apt/keyrings/evcc-stable.gpg || msg_error "Failed to download GPG key"
-echo "deb [signed-by=/etc/apt/keyrings/evcc-stable.gpg] https://dl.evcc.io/public/evcc/stable/deb/debian $(lsb_release -cs) main" >/etc/apt/sources.list.d/evcc-stable.list || msg_error "Failed to add EVCC repository"
-$STD sudo apt update
+curl -fsSL https://dl.evcc.io/public/evcc/stable/gpg.EAD5D0E07B0EC0FD.key | gpg --dearmor -o /etc/apt/keyrings/evcc-stable.gpg 
+echo "deb [signed-by=/etc/apt/keyrings/evcc-stable.gpg] https://dl.evcc.io/public/evcc/stable/deb/debian $(lsb_release -cs) main" >/etc/apt/sources.list.d/evcc-stable.list 
+$STD apt update
 msg_ok "evcc Repository setup sucessfully"
 
 msg_info "Installing ${APPLICATION}"
-$STD sudo apt install -y evcc
-$STD systemctl enable --now evcc.service
+$STD apt install -y evcc
+systemctl enable --now evcc.service
 msg_ok "Installed ${APPLICATION}"
 
 motd_ssh

--- a/install/evcc-install.sh
+++ b/install/evcc-install.sh
@@ -19,21 +19,26 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y \
   curl \
   sudo \
-  mc 
+  mc \
+  debian-keyring \
+  debian-archive-keyring \
+  lsb-release \
+  gpg \
+  apt-transport-https
 msg_ok "Installed Dependencies"
 
-RELEASE=$(curl -s https://api.github.com/repos/evcc-io/evcc/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
-msg_info "Installing ${APPLICATION} ${RELEASE}"
-wget -q "https://github.com/evcc-io/evcc/releases/download/${RELEASE}/evcc_${RELEASE}_amd64.deb"
-$STD dpkg -i evcc_${RELEASE}_amd64.deb
-echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
-msg_ok "Installed ${APPLICATION} ${RELEASE}"
+msg_info "Setting up evcc Repository"
+curl -fsSL https://dl.evcc.io/public/evcc/stable/gpg.EAD5D0E07B0EC0FD.key | gpg --dearmor -o /etc/apt/keyrings/evcc-stable.gpg || msg_error "Failed to download GPG key"
+echo "deb [signed-by=/etc/apt/keyrings/evcc-stable.gpg] https://dl.evcc.io/public/evcc/stable/deb/debian $(lsb_release -cs) main" >/etc/apt/sources.list.d/evcc-stable.list || msg_error "Failed to add EVCC repository"
+
+msg_info "Installing ${APPLICATION}"
+$STD sudo apt install -y evcc
+msg_ok "Installed ${APPLICATION}"
 
 motd_ssh
 customize
 
 msg_info "Cleaning up"
-rm -rf evcc_${RELEASE}_amd64.deb
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"

--- a/install/evcc-install.sh
+++ b/install/evcc-install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: MickLesk (Canbiz)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+# Source: https://github.com/evcc-io/evcc
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc 
+msg_ok "Installed Dependencies"
+
+RELEASE=$(curl -s https://api.github.com/repos/evcc-io/evcc/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
+msg_info "Installing ${APPLICATION} ${RELEASE}"
+wget -q "https://github.com/evcc-io/evcc/releases/download/${RELEASE}/evcc_${RELEASE}_amd64.deb"
+$STD dpkg -i evcc_${RELEASE}_amd64.deb
+echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
+msg_ok "Installed ${APPLICATION} ${RELEASE}"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+rm -rf evcc_${RELEASE}_amd64.deb
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/install/evcc-install.sh
+++ b/install/evcc-install.sh
@@ -30,10 +30,10 @@ echo "deb [signed-by=/etc/apt/keyrings/evcc-stable.gpg] https://dl.evcc.io/publi
 $STD apt update
 msg_ok "evcc Repository setup sucessfully"
 
-msg_info "Installing ${APPLICATION}"
+msg_info "Installing evcc"
 $STD apt install -y evcc
 systemctl enable --now evcc.service
-msg_ok "Installed ${APPLICATION}"
+msg_ok "Installed evcc"
 
 motd_ssh
 customize


### PR DESCRIPTION
## Description
### Add new LXC for evcc
evcc is an extensible EV Charge Controller and home energy management system.

After installation need to run in lxc console:
evcc configure

=> this configure the whole solar, battery and wallboxes in da house

I was able to test it successfully because I have a solar system + storage + wallbox. 
However, the web interface generally always works. ( Shows demo data in this case without configuration)

**Please note! -- Requirements**
1) a supported wallbox or smart power plug
2) a supported measuring device at the house connection, or alternatively a supported PV inverter or other measuring device that measures the current generation power
3) a supported system on which evcc is running (Proxmox LXC is fine)

Optional:
- One or more supported vehicles whose state of charge is retrieved
- further supported wallboxes, switchable sockets, PV generation and battery storage systems
- a supported energy management system (such as SMA Sunny Home Manager) or a dynamic electricity tariff

## Type of change
- [x] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)


![image](https://github.com/user-attachments/assets/ec25bf9e-9a54-40c7-861c-d19aa159c7bd)
