### PR TITLE
Update Jellyseerr 

### DIFF
--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -21,7 +21,7 @@ echo -e "Loading..."
 APP="Jellyseerr"
 var_disk="8"
 var_cpu="2"
-var_ram="2048"
+var_ram="4096"
 var_os="debian"
 var_version="12"
 variables
@@ -76,7 +76,7 @@ if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_v
   mv jellyseerr-${RELEASE:1} /opt/jellyseerr
   cd /opt/jellyseerr
   pnpm install &>/dev/null
-  yarn build &>/dev/null
+  pnpm build &>/dev/null
   echo "${RELEASE}" >/opt/${APP}_version.txt
   msg_ok "Updated ${APP}"
 

--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -55,27 +55,52 @@ function default_settings() {
 function update_script() {
 header_info
 if [[ ! -d /opt/jellyseerr ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-msg_info "Updating $APP"
-systemctl stop jellyseerr
-cd /opt/jellyseerr
-output=$(git pull)
-git pull &>/dev/null
-if echo "$output" | grep -q "Already up to date."
-then
-  msg_ok " $APP is already up to date."
-  systemctl start jellyseerr
-  exit
+if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
 fi
-CYPRESS_INSTALL_BINARY=0 yarn install --frozen-lockfile --network-timeout 1000000 &>/dev/null
-yarn build &>/dev/null
-systemctl start jellyseerr
-msg_ok "Updated $APP"
+RELEASE=$(curl -s https://api.github.com/repos/Fallenbagel/jellyseerr/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
+if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+  msg_info "Stopping ${APP}"
+  systemctl stop jellyseerr
+  msg_ok "${APP} Stopped"
+
+  msg_info "Setting Container to Extended Resources"
+  pct set $CTID -memory 4096
+  msg_ok "Set Container to Extended Resources"
+  
+  msg_info "Updating ${APP} to ${RELEASE}"
+  cd /opt
+  wget -q "https://github.com/Fallenbagel/jellyseerr/archive/refs/tags/${RELEASE}.zip"
+  unzip -q ${RELEASE}.zip 
+  mv jellyseerr-${RELEASE:1} /opt/jellyseerr
+  cd /opt/jellyseerr
+  pnpm install &>/dev/null
+  yarn build &>/dev/null
+  echo "${RELEASE}" >/opt/${APP}_version.txt
+  msg_ok "Updated ${APP}"
+
+  msg_info "Starting ${APP}"
+  systemctl start jellyseerrr
+  msg_ok "Started ${APP}"
+
+  msg_info "Cleaning Up"
+  rm -R ${RELEASE}.zip 
+  msg_ok "Cleaned"
+  msg_ok "Updated Successfully"
+else
+  msg_ok "No update required. ${APP} is already at ${RELEASE}"
+fi
 exit
 }
 
 start
 build_container
 description
+
+msg_info "Setting Container to Normal Resources"
+pct set $CTID -memory 2048
+msg_ok "Set Container to Normal Resources"
 
 msg_ok "Completed Successfully!\n"
 echo -e "${APP} should be reachable by going to the following URL.

--- a/install/jellyseerr-install.sh
+++ b/install/jellyseerr-install.sh
@@ -33,23 +33,28 @@ $STD apt-get update
 $STD apt-get install -y nodejs
 msg_ok "Installed Node.js"
 
-msg_info "Installing Yarn"
+msg_info "Installing Yarn/pnpm"
 $STD npm install -g yarn
-msg_ok "Installed Yarn"
+$STD npm install -g pnpm
+msg_ok "Installed Yarn/pnpm"
 
 msg_info "Installing Jellyseerr (Patience)"
-git clone -q https://github.com/Fallenbagel/jellyseerr.git /opt/jellyseerr
+RELEASE=$(curl -s https://api.github.com/repos/Fallenbagel/jellyseerr/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
+cd /opt
+wget -q "https://github.com/Fallenbagel/jellyseerr/archive/refs/tags/${RELEASE}.zip"
+unzip -q ${RELEASE}.zip 
+mv jellyseerr-${RELEASE:1} /opt/jellyseerr
+rm -R ${RELEASE}.zip 
 cd /opt/jellyseerr
-$STD git checkout main
-CYPRESS_INSTALL_BINARY=0 yarn install --frozen-lockfile --network-timeout 1000000 &>/dev/null
-$STD yarn install
+$STD pnpm install
 $STD yarn build
 mkdir -p /etc/jellyseerr/
 cat <<EOF >/etc/jellyseerr/jellyseerr.conf
 PORT=5055
 # HOST=0.0.0.0
-# JELLYFIN_TYPE=emby
+# FORCE_IPV4_FIRST=true
 EOF
+echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
 msg_ok "Installed Jellyseerr"
 
 msg_info "Creating Service"

--- a/install/jellyseerr-install.sh
+++ b/install/jellyseerr-install.sh
@@ -33,10 +33,9 @@ $STD apt-get update
 $STD apt-get install -y nodejs
 msg_ok "Installed Node.js"
 
-msg_info "Installing Yarn/pnpm"
-$STD npm install -g yarn
+msg_info "Installing pnpm"
 $STD npm install -g pnpm
-msg_ok "Installed Yarn/pnpm"
+msg_ok "Installed pnpm"
 
 msg_info "Installing Jellyseerr (Patience)"
 RELEASE=$(curl -s https://api.github.com/repos/Fallenbagel/jellyseerr/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
@@ -47,7 +46,7 @@ mv jellyseerr-${RELEASE:1} /opt/jellyseerr
 rm -R ${RELEASE}.zip 
 cd /opt/jellyseerr
 $STD pnpm install
-$STD yarn build
+$STD pnpm build
 mkdir -p /etc/jellyseerr/
 cat <<EOF >/etc/jellyseerr/jellyseerr.conf
 PORT=5055
@@ -68,7 +67,7 @@ EnvironmentFile=/etc/jellyseerr/jellyseerr.conf
 Environment=NODE_ENV=production
 Type=exec
 WorkingDirectory=/opt/jellyseerr
-ExecStart=/usr/bin/yarn start
+ExecStart=/usr/bin/pnpm start
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
https://github.com/tteck/Proxmox/issues/3904
## Description
There was a big major update here, which changed some of the dependencies.

Unfortunately, deploying with yarn build now also consumes significantly more resources, which is why I had to increase the RAM to 4GB (and then reduce it again).

Update and Reworked Jellyfin LXC
-> Fix Bug: https://github.com/tteck/Proxmox/issues/3904
-> Add RELEASE as Github-Zip (not git clone)
-> Add Version Check for Update
-> Add pnpm, because CYPRESS_YARN dont work anymore. 


I'm not sure whether you want to add anything to the “Documantation update required”, after all:
`pnpm install` was added

And for old installations, this may have to be installed later:
`npm install -g pnpm`

In any case, old versions don't have the release check, or doesn't that matter?
`if [[ ! -f /opt/${APP}_version.txt ]] || [[ “${RELEASE}” != “$(cat /opt/${APP}_version.txt)” ]]; then`


- [x] Bug fix (non-breaking change that resolves an issue)
- [x] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [?] Documentation update required (this change requires an update to the documentation)

