### PR TITLE
Add new LXC: Elasticsearch

### DIFF
--- a/ct/elasticsearch.sh
+++ b/ct/elasticsearch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/ELKozel/Proxmox/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
 # Copyright (c) 2024 ELKozel
 # Author: T.H. (ELKozel)
 # License: MIT

--- a/ct/elasticsearch.sh
+++ b/ct/elasticsearch.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/ELKozel/Proxmox/main/misc/build.func)
+# Copyright (c) 2024 ELKozel
+# Author: T.H. (ELKozel)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"
+ _____ _           _   _                              _     
+| ____| | __ _ ___| |_(_) ___ ___  ___  __ _ _ __ ___| |__  
+|  _| | |/ _` / __| __| |/ __/ __|/ _ \/ _` | '__/ __| '_ \ 
+| |___| | (_| \__ \ |_| | (__\__ \  __/ (_| | | | (__| | | |
+|_____|_|\__,_|___/\__|_|\___|___/\___|\__,_|_|  \___|_| |_|
+
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Elasticsearch"
+var_disk="16"
+var_cpu="4"
+var_ram="4096"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+  header_info
+  if [[ ! -f /etc/systemd/system/elasticsearch.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+  if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
+    read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
+    [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
+  fi
+
+  msg_info "Stopping ${APP}"
+  $STD /bin/systemctl stop elasticsearch.service
+  msg_ok "Stopped ${APP}"
+
+  msg_info "Updating ${APP}"
+  $STD apt-get install elasticsearch &>/dev/null
+  msg_ok "Updated ${APP}"
+
+  msg_info "Starting ${APP}"
+  $STD /bin/systemctl restart elasticsearch.service
+  msg_ok "Started ${APP}"
+
+  msg_ok "Updated Successfully"
+  exit
+}
+
+function ask_extend_mmap() {
+  echo "Elasticsearch recommends extending the vm.max_map_count on the host"
+  read -r -p "Would you like to extend mmap count? <y/N>" prompt
+  if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+    msg_info "Extending mmap count"
+    sysctl -w vm.max_map_count=262144 >/dev/null
+    # Check if the setting is persistent
+    if ! grep -q "vm.max_map_count" /etc/sysctl.conf; then
+      echo "vm.max_map_count=262144" >> /etc/sysctl.conf
+    fi
+    msg_ok "Extended mmap count"
+  fi
+}
+
+start
+ask_extend_mmap
+build_container
+description
+
+msg_info "Configuring User"
+ELASTIC_USER=elastic
+KIBANA_USER=kibana
+ELASTIC_PASSWORD=$(lxc-attach -n "$CTID" -- bash -c "/usr/share/elasticsearch/bin/elasticsearch-reset-password -sbf -u $ELASTIC_USER" || exit)
+KIBANA_TOKEN=$(lxc-attach -n "$CTID" -- bash -c "/usr/share/elasticsearch/bin/elasticsearch-create-enrollment-token -s $KIBANA_USER" || exit)
+ENROLLMENT_TOKEN=$(lxc-attach -n "$CTID" -- bash -c "/usr/share/elasticsearch/bin/elasticsearch-create-enrollment-token -s node" || exit)
+msg_ok "Configured User"
+
+msg_info "Checking Health"
+ELASTIC_PORT=9200
+curl -s -XGET --insecure --fail --user $ELASTIC_USER:$ELASTIC_PASSWORD https://${IP}:$ELASTIC_PORT/_cluster/health?pretty >/dev/null
+msg_ok "Checked Health"
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} is installed, you can check it's health by running:
+${BL}curl -XGET --insecure --fail --user $ELASTIC_USER:$ELASTIC_PASSWORD https://${IP}:$ELASTIC_PORT/_cluster/health?pretty${CL}
+Elasticsearch credentials are:
+User: ${BL}${ELASTIC_USER}${CL}
+Password: ${BL}${ELASTIC_PASSWORD}${CL}
+Enrollment and Kibana tokens were also generated for you:
+Kibana Token: ${BL}${KIBANA_TOKEN}${CL}
+Enrollment Token: ${BL}${ENROLLMENT_TOKEN}${CL} \n"

--- a/ct/elasticsearch.sh
+++ b/ct/elasticsearch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/ELKozel/Proxmox/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # Co-Author: T.H. (ELKozel)

--- a/install/elasticsearch-install.sh
+++ b/install/elasticsearch-install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck (tteckster)
+# Co-Author: T.H. (ELKozel)
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y wget
+$STD apt-get install -y sudo
+$STD apt-get install -y mc
+$STD apt-get install -y ca-certificates
+$STD apt-get install apt-transport-https
+$STD apt-get install -y gnupg
+msg_ok "Installed Dependencies"
+
+msg_info "Setting up Elastic Repository"
+mkdir -p /etc/apt/keyrings
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" >/etc/apt/sources.list.d/elastic-8.x.list
+msg_ok "Set up Elastic Repository"
+
+msg_info "Installing Elastcisearch"
+$STD apt-get update
+$STD apt-get install elasticsearch
+msg_ok "Installed Elastcisearch"
+
+msg_info "Configuring Elasticsearch Memory"
+$STD sed -i -E 's/## -Xms[0-9]+[Ggm]/-Xms3g/' /etc/elasticsearch/jvm.options
+$STD sed -i -E 's/## -Xmx[0-9]+[Ggm]/-Xmx3g/' /etc/elasticsearch/jvm.options
+msg_ok "Elastcisearch Configured to use 3GB of RAM"
+
+msg_info "Creating Service"
+$STD /bin/systemctl daemon-reload
+$STD /bin/systemctl enable elasticsearch.service
+$STD /bin/systemctl start elasticsearch.service
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/install/elasticsearch-install.sh
+++ b/install/elasticsearch-install.sh
@@ -15,34 +15,74 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y wget
+$STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
-$STD apt-get install -y ca-certificates
-$STD apt-get install apt-transport-https
+$STD apt-get install -y apt-transport-https
 $STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up Elastic Repository"
-mkdir -p /etc/apt/keyrings
 wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" >/etc/apt/sources.list.d/elastic-8.x.list
 msg_ok "Set up Elastic Repository"
 
 msg_info "Installing Elastcisearch"
 $STD apt-get update
-$STD apt-get install elasticsearch
+$STD apt-get install -y elasticsearch
 msg_ok "Installed Elastcisearch"
 
 msg_info "Configuring Elasticsearch Memory"
-$STD sed -i -E 's/## -Xms[0-9]+[Ggm]/-Xms3g/' /etc/elasticsearch/jvm.options
-$STD sed -i -E 's/## -Xmx[0-9]+[Ggm]/-Xmx3g/' /etc/elasticsearch/jvm.options
+sed -i -E 's/## -Xms[0-9]+[Ggm]/-Xms3g/' /etc/elasticsearch/jvm.options
+sed -i -E 's/## -Xmx[0-9]+[Ggm]/-Xmx3g/' /etc/elasticsearch/jvm.options
 msg_ok "Elastcisearch Configured to use 3GB of RAM"
 
 msg_info "Creating Service"
-$STD /bin/systemctl daemon-reload
-$STD /bin/systemctl enable elasticsearch.service
-$STD /bin/systemctl start elasticsearch.service
+cat <<EOF >/etc/systemd/system/Elasticsearch.service
+[Unit]
+Description=Elasticsearch
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=notify
+NotifyAccess=all
+RuntimeDirectory=elasticsearch
+PrivateTmp=true
+Environment=ES_HOME=/usr/share/elasticsearch
+Environment=ES_PATH_CONF=/etc/elasticsearch
+Environment=PID_DIR=/var/run/elasticsearch
+Environment=ES_SD_NOTIFY=true
+EnvironmentFile=-/etc/default/elasticsearch
+
+WorkingDirectory=/usr/share/elasticsearch
+
+User=elasticsearch
+Group=elasticsearch
+
+ExecStart=/usr/share/elasticsearch/bin/systemd-entrypoint -p \${PID_DIR}/elasticsearch.pid --quiet
+
+StandardOutput=journal
+StandardError=inherit
+
+LimitNOFILE=65535
+LimitNPROC=4096
+LimitAS=infinity
+LimitFSIZE=infinity
+
+TimeoutStopSec=0
+
+KillSignal=SIGTERM
+KillMode=process
+SendSIGKILL=no
+SuccessExitStatus=143
+
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now Elasticsearch.service
 msg_ok "Created Service"
 
 motd_ssh


### PR DESCRIPTION
## Description
This provides two new products by Elastic, which are widely used for system and security monitoring. The added scripts are:

- ct/elasticsearch.sh
- install/elasticsearch-install.sh

Description about the files are below.

### elasticsearch.sh
The file provides a typical installation, based on the `adguard.sh` installation script provided, with a couple of changes:
#### ask_extend_mmap() function
The function asks the user if this setting on the host could be changed. Elasticsearch [advises](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html) this setting to be changed, otherwise it could result in out-of-memory exceptions.

#### `Configuring User` and `Checking Health` steps
The steps are supposed to help the user with the configuration of Elasticsearch, extracting needed information by the user and making sure that the health of the cluster is fine. The information from these steps is also displayed in the final message after the installation is complete.

### install/elasticsearch-install.sh
This script follows the `n8n-install.sh` script, completing almost the same steps for installation using `apt-get`. The only addion is the `Configuring Elasticsearch Memory` step, which sets the RAM limit for Elasticsearch. The changes are according to the [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.15/advanced-configuration.html#set-jvm-options) and prevent Elasticsearch from being killed by the JVM OOM.

## Fixes
No issues were created for this improvement.

## Type of change

Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [x] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)