### PR TITLE
Add new LXC: Cockpit

### DIFF
--- a/ct/cockpit.sh
+++ b/ct/cockpit.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: havardthom
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"     
+   ______           __         _ __ 
+  / ____/___  _____/ /______  (_) /_
+ / /   / __ \/ ___/ //_/ __ \/ / __/
+/ /___/ /_/ / /__/ ,< / /_/ / / /_  
+\____/\____/\___/_/|_/ .___/_/\__/  
+                    /_/             
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Cockpit"
+var_disk="2"
+var_cpu="1"
+var_ram="512"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+if [[ ! -d /etc/cockpit ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+UPD=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "SUPPORT" --radiolist --cancel-button Exit-Script "Spacebar = Select" 11 58 4 \
+  "1" "Update LXC" ON \
+  "2" "Install cockpit-file-sharing" OFF \
+  "3" "Install cockpit-identities" OFF \
+  "4" "Install cockpit-navigator" OFF \
+  3>&1 1>&2 2>&3)
+
+header_info
+if [ "$UPD" == "1" ]; then
+  msg_info "Updating ${APP} LXC"
+  apt-get update &>/dev/null
+  apt-get -y upgrade &>/dev/null
+  msg_ok "Updated ${APP} LXC"
+  exit
+fi
+if [ "$UPD" == "2" ]; then
+  msg_info "Installing dependencies (patience)"
+  apt-get install -y attr &>/dev/null
+  apt-get install -y nfs-kernel-server &>/dev/null
+  apt-get install -y samba &>/dev/null
+  apt-get install -y samba-common-bin &>/dev/null
+  apt-get install -y winbind &>/dev/null
+  apt-get install -y gawk &>/dev/null
+  msg_ok "Installed dependencies"
+  msg_info "Installing Cockpit file sharing"
+  LATEST=$(curl -s https://api.github.com/repos/45Drives/cockpit-file-sharing/releases/latest  | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  wget -q https://github.com/45Drives/cockpit-file-sharing/releases/download/v${LATEST}/cockpit-file-sharing_${LATEST}-1focal_all.deb
+  dpkg -i cockpit-file-sharing_${LATEST}-1focal_all.deb &>/dev/null
+  rm cockpit-file-sharing_${LATEST}-1focal_all.deb
+  msg_ok "Installed Cockpit file sharing"
+  exit
+fi
+if [ "$UPD" == "3" ]; then
+  msg_info "Installing dependencies (patience)"
+  apt-get install -y psmisc &>/dev/null
+  apt-get install -y samba &>/dev/null
+  apt-get install -y samba-common-bin &>/dev/null
+  msg_ok "Installed dependencies"
+  msg_info "Installing Cockpit identities"
+  LATEST=$(curl -s https://api.github.com/repos/45Drives/cockpit-identities/releases/latest  | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  wget -q https://github.com/45Drives/cockpit-identities/releases/download/v${LATEST}/cockpit-identities_${LATEST}-1focal_all.deb
+  dpkg -i cockpit-identities_${LATEST}-1focal_all.deb &>/dev/null
+  rm cockpit-identities_${LATEST}-1focal_all.deb
+  msg_ok "Installed Cockpit identities"
+  exit
+fi
+if [ "$UPD" == "4" ]; then
+  msg_info "Installing dependencies"
+  apt-get install -y rsync &>/dev/null
+  apt-get install -y zip &>/dev/null
+  msg_ok "Installed dependencies"
+  msg_info "Installing Cockpit navigator"
+  LATEST=$(curl -s https://api.github.com/repos/45Drives/cockpit-navigator/releases/latest  | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  wget -q https://github.com/45Drives/cockpit-navigator/releases/download/v${LATEST}/cockpit-navigator_${LATEST}-1focal_all.deb
+  dpkg -i cockpit-navigator_${LATEST}-1focal_all.deb &>/dev/null
+  rm cockpit-navigator_${LATEST}-1focal_all.deb
+  msg_ok "Installed Cockpit navigator"
+  exit
+fi
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} should be reachable by going to the following URL.
+         ${BL}http://${IP}:9090${CL} \n"

--- a/ct/cockpit.sh
+++ b/ct/cockpit.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
-# Author: havardthom
+# Author: tteck
+# Co-Author: havardthom
 # License: MIT
 # https://github.com/tteck/Proxmox/raw/main/LICENSE
 
 function header_info {
 clear
 cat <<"EOF"     
-   ______           __         _ __ 
+   ______           __         _ __
   / ____/___  _____/ /______  (_) /_
  / /   / __ \/ ___/ //_/ __ \/ / __/
-/ /___/ /_/ / /__/ ,< / /_/ / / /_  
-\____/\____/\___/_/|_/ .___/_/\__/  
-                    /_/             
+/ /___/ /_/ / /__/ ,< / /_/ / / /_
+\____/\____/\___/_/|_/ .___/_/\__/
+                    /_/
 EOF
 }
 header_info

--- a/install/cockpit-install.sh
+++ b/install/cockpit-install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: havardthom
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+# Source: https://github.com/cockpit-project/cockpit
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl
+$STD apt-get install -y sudo
+$STD apt-get install -y mc
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Cockpit"
+$STD apt install -y cockpit --no-install-recommends
+sed -i "s/root//g" /etc/cockpit/disallowed-users
+msg_ok "Installed Cockpit"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"


### PR DESCRIPTION
> [!NOTE]
I am meticulous when it comes to merging code into the main branch, so please understand that I may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description
[Cockpit](https://cockpit-project.org/) is an easy-to-use, integrated, glanceable, and open web-based interface for servers. It is highly extensible and a popular choice for setting up fileservers on Proxmox (mostly due to the following guide from apalrd: https://www.apalrd.net/posts/2023/ultimate_nas/). It has also been requested in https://github.com/tteck/Proxmox/discussions/50#discussioncomment-10960061

The script allows optionally installing the following Cockpit modules used for setting up a fileserver:
45Drives Cockpit File Sharing - https://github.com/45Drives/cockpit-file-sharing
45Drives Cockpit Identities - https://github.com/45Drives/cockpit-identities/
45Drives Cockpit Navigator - https://github.com/45Drives/cockpit-navigator

![cockpit-lxc-created](https://github.com/user-attachments/assets/29aeca5a-f674-4229-a5bc-0a806e8d8e54)
![cockpit-applications](https://github.com/user-attachments/assets/1bde195e-ff56-4901-9f4d-217089f94120)
![cockpit-file-sharing](https://github.com/user-attachments/assets/627e123e-83a0-426b-8180-46476428d97d)
![cockpit-identities](https://github.com/user-attachments/assets/0752681e-84b6-4f0d-b90f-d62fbad8cfa3)
![cockpit-navigator](https://github.com/user-attachments/assets/2e75d2ea-441d-4bb6-a336-5bacd103cbe4)
![cockpit](https://github.com/user-attachments/assets/44703702-9bcc-4ad0-ae01-60999b42aa9e)

## Type of change

Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [x] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)

