### PR TITLE
Add new LXC: Neo4j

### DIFF
--- a/ct/neo4j.sh
+++ b/ct/neo4j.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: havardthom
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+function header_info {
+clear
+cat <<"EOF"     
+    _   __           __ __  _ 
+   / | / /__  ____  / // / (_)
+  /  |/ / _ \/ __ \/ // /_/ /
+ / /|  /  __/ /_/ /__  __/ /
+/_/ |_/\___/\____/  /_/_/ /
+                     /___/
+EOF
+}
+header_info
+echo -e "Loading..."
+APP="Neo4j"
+var_disk="4"
+var_cpu="1"
+var_ram="1024"
+var_os="debian"
+var_version="12"
+variables
+color
+catch_errors
+
+function default_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="$var_disk"
+  CORE_COUNT="$var_cpu"
+  RAM_SIZE="$var_ram"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  echo_default
+}
+
+function update_script() {
+header_info
+if [[ ! -d /etc/neo4j ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Updating ${APP}"
+apt-get update &>/dev/null
+apt-get -y upgrade &>/dev/null
+msg_ok "Updated Successfully"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${APP} Browser should be reachable by going to the following URL.
+         ${BL}http://${IP}:7474${CL} \n"

--- a/install/neo4j-install.sh
+++ b/install/neo4j-install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2024 tteck
+# Author: tteck
+# Co-Author: havardthom
+# License: MIT
+# https://github.com/tteck/Proxmox/raw/main/LICENSE
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y curl
+$STD apt-get install -y sudo
+$STD apt-get install -y mc
+$STD apt-get install -y gpg
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Neo4j (patience)"
+wget -qO- https://debian.neo4j.com/neotechnology.gpg.key | gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable latest' > /etc/apt/sources.list.d/neo4j.list
+$STD apt-get update
+$STD apt-get install -y neo4j
+sed -i '/server.default_listen_address/s/^#//' /etc/neo4j/neo4j.conf
+systemctl enable -q --now neo4j
+msg_ok "Installed Neo4j"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"


### PR DESCRIPTION
> [!NOTE]
I am meticulous when it comes to merging code into the main branch, so please understand that I may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

[Neo4j](https://neo4j.com/) is the world’s leading Graph Database. It is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions. The programmer works with a flexible network structure of nodes and relationships rather than static tables — yet enjoys all the benefits of enterprise-quality database. For many applications, Neo4j offers orders of magnitude performance benefits compared to relational DBs.

This LXC installs Neo4j Community Edition which is free to use (https://neo4j.com/licensing/).

Default username and password is `neo4j | neo4j` and there's a password change prompt on first login.

![neo4j-installed](https://github.com/user-attachments/assets/d982dd90-330c-4fa2-a341-629c1aade54f)
![neo4j-browser](https://github.com/user-attachments/assets/e6c3bf5c-d28d-4428-910b-cc5a749d6f47)
![neo4j-browser-password-prompt](https://github.com/user-attachments/assets/f8a2e2db-f75f-44fb-a220-b3adf43a8b16)
![neo4j-browser-logged-in](https://github.com/user-attachments/assets/9f5f1827-754e-4181-9b57-8331ed878229)
![neo4j-browser-query](https://github.com/user-attachments/assets/7d39a1b1-b32f-4df0-a1cc-07d59a83e5ed)

## Type of change

Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [x] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Documentation update required (this change requires an update to the documentation)

