### PR TITLE
use pm2 with systemd to make pingvin-share survive reboots

### DIFF
--- a/ct/pingvin.sh
+++ b/ct/pingvin.sh
@@ -56,7 +56,7 @@ function update_script() {
 header_info
 if [[ ! -d /opt/pingvin-share ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
 msg_info "Stopping Pingvin Share"
-pm2 stop pingvin-share-backend pingvin-share-frontend &>/dev/null
+systemctl stop pm2-root.service
 msg_ok "Stopped Pingvin Share"
 
 msg_info "Updating Pingvin Share"
@@ -72,7 +72,7 @@ npm run build &>/dev/null
 msg_ok "Updated Pingvin Share"
 
 msg_info "Starting Pingvin Share"
-pm2 start pingvin-share-backend pingvin-share-frontend &>/dev/null
+systemctl start pm2-root.service
 msg_ok "Started Pingvin Share"
 
 msg_ok "Updated Successfully"

--- a/install/pingvin-install.sh
+++ b/install/pingvin-install.sh
@@ -47,7 +47,10 @@ sed -i '/"admin.config.smtp.allow-unauthorized-certificates":\|admin.config.smtp
 $STD npm install
 $STD npm run build
 $STD pm2 start --name="pingvin-share-frontend" npm -- run start
-$STD pm2 startup
+# create and enable pm2-root systemd script
+$STD pm2 startup systemd 
+# save running pm2 processes so pingvin-share can survive reboots
+$STD pm2 save
 msg_ok "Installed Pingvin Share"
 
 motd_ssh


### PR DESCRIPTION
> [!NOTE]
I am meticulous when it comes to merging code into the main branch, so please understand that I may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Pingvin-share CT at least for me it could not survive reboot. I learned it is because there is no pm2--root systemd service present to start pm2 processes on reboot/systemd stop/restarting of service. I added commands that create systemd service and also altered update script to use systemd instead of pm2 directly. 

Fixes #3936 

## Type of change

Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Documentation update required (this change requires an update to the documentation)

