### PR TITLE
fix(zoraxy): install stable release instead of building from main branch

### DIFF
--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -54,14 +54,13 @@ function default_settings() {
 
 function update_script() {
 header_info
-if [[ ! -f /etc/systemd/system/zoraxy.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+if [[ ! -f /etc/systemd/system/zoraxy.service ]] || [[ ! -x "/opt/zoraxy" ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
 RELEASE="$(curl -s https://api.github.com/repos/tobychui/zoraxy/releases | grep -oP '"tag_name":\s*"\K[\d.]+?(?=")' | sort -V | tail -n1)"
 msg_info "Updating ${APP} LXC to ${RELEASE}"
-if [[ "${RELEASE}" != "$(cat "/opt/${APP}_version.txt")" ]] || [[ ! -f "/opt/${APP}_version.txt" ]]; then
+if [[ "${RELEASE}" != "$(/opt/zoraxy --version | cut -d' ' -f4)" ]]; then
   wget -q "https://github.com/tobychui/zoraxy/releases/download/${RELEASE}/zoraxy_linux_amd64"
-  install zoraxy_linux_amd64 /usr/bin/zoraxy
+  install zoraxy_linux_amd64 /opt/zoraxy
   rm zoraxy_linux_amd64
-  echo "${RELEASE}" > "/opt/${APP}_version.txt"
   systemctl restart zoraxy.service
   msg_ok "Updated ${APP} LXC"
 else

--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -20,7 +20,7 @@ header_info
 echo -e "Loading..."
 APP="Zoraxy"
 var_disk="6"
-var_cpu="4"
+var_cpu="2"
 var_ram="2048"
 var_os="debian"
 var_version="12"
@@ -54,20 +54,19 @@ function default_settings() {
 
 function update_script() {
 header_info
-if [[ ! -d /opt/zoraxy/src ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
-msg_info "Updating $APP"
-systemctl stop zoraxy
-cd /opt/zoraxy/src
-systemctl stop zoraxy
-if git pull | grep -q 'Already up to date.'; then
-  msg_ok "Already up to date. No update required."
+if [[ ! -f /etc/systemd/system/zoraxy.service ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+RELEASE="$(curl -s https://api.github.com/repos/tobychui/zoraxy/releases | grep -oP '"tag_name":\s*"\K[\d.]+?(?=")' | sort -V | tail -n1)"
+msg_info "Updating ${APP} LXC to ${RELEASE}"
+if [[ "${RELEASE}" != "$(cat "/opt/${APP}_version.txt")" ]] || [[ ! -f "/opt/${APP}_version.txt" ]]; then
+  wget -q "https://github.com/tobychui/zoraxy/releases/download/${RELEASE}/zoraxy_linux_amd64"
+  install zoraxy_linux_amd64 /usr/bin/zoraxy
+  rm zoraxy_linux_amd64
+  echo "${RELEASE}" > "/opt/${APP}_version.txt"
+  systemctl restart traefik.service
+  msg_ok "Updated ${APP} LXC"
 else
-  go mod tidy
-  go build
-  msg_ok "Updated $APP"
+  msg_ok "No update required. ${APP} is already at ${RELEASE}"
 fi
-systemctl start zoraxy
 exit
 }
 
@@ -75,9 +74,6 @@ start
 build_container
 description
 
-msg_info "Setting Container to Normal Resources"
-pct set $CTID -cores 2
-msg_ok "Set Container to Normal Resources"
 msg_ok "Completed Successfully!\n"
 echo -e "${APP} should be reachable by going to the following URL.
          ${BL}http://${IP}:8000${CL} \n"

--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -62,7 +62,7 @@ if [[ "${RELEASE}" != "$(cat "/opt/${APP}_version.txt")" ]] || [[ ! -f "/opt/${A
   install zoraxy_linux_amd64 /usr/bin/zoraxy
   rm zoraxy_linux_amd64
   echo "${RELEASE}" > "/opt/${APP}_version.txt"
-  systemctl restart traefik.service
+  systemctl restart zoraxy.service
   msg_ok "Updated ${APP} LXC"
 else
   msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT

--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT

--- a/install/zoraxy-install.sh
+++ b/install/zoraxy-install.sh
@@ -20,7 +20,7 @@ $STD apt-get install -y mc
 $STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
-RELEASE="$(curl -s https://api.github.com/repos/tobychui/zoraxy/releases | ggrep -oP '"tag_name":\s*"\K[\d.]+?(?=")' | sort -V | tail -n1)"
+RELEASE="$(curl -s https://api.github.com/repos/tobychui/zoraxy/releases | grep -oP '"tag_name":\s*"\K[\d.]+?(?=")' | sort -V | tail -n1)"
 msg_info "Installing Zoraxy v${RELEASE}"
 wget -q "https://github.com/tobychui/zoraxy/releases/download/${RELEASE}/zoraxy_linux_amd64"
 install zoraxy_linux_amd64 /usr/bin/zoraxy

--- a/install/zoraxy-install.sh
+++ b/install/zoraxy-install.sh
@@ -22,8 +22,8 @@ msg_ok "Installed Dependencies"
 RELEASE="$(curl -s https://api.github.com/repos/tobychui/zoraxy/releases | grep -oP '"tag_name":\s*"\K[\d.]+?(?=")' | sort -V | tail -n1)"
 msg_info "Installing Zoraxy v${RELEASE}"
 wget -q "https://github.com/tobychui/zoraxy/releases/download/${RELEASE}/zoraxy_linux_amd64"
-install zoraxy_linux_amd64 /usr/bin/zoraxy
-echo "${RELEASE}" > "/opt/${APPLICATION}_version.txt"
+install zoraxy_linux_amd64 /opt/zoraxy
+rm zoraxy_linux_amd64
 msg_ok "Installed Zoraxy"
 
 msg_info "Creating Service"
@@ -33,7 +33,7 @@ Description=General purpose request proxy and forwarding tool
 After=syslog.target network-online.target
 
 [Service]
-ExecStart=/usr/bin/zoraxy
+ExecStart=/opt/zoraxy
 Restart=always
 
 [Install]

--- a/install/zoraxy-install.sh
+++ b/install/zoraxy-install.sh
@@ -17,7 +17,6 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
-$STD apt-get install -y git
 msg_ok "Installed Dependencies"
 
 RELEASE="$(curl -s https://api.github.com/repos/tobychui/zoraxy/releases | grep -oP '"tag_name":\s*"\K[\d.]+?(?=")' | sort -V | tail -n1)"

--- a/misc/build.func
+++ b/misc/build.func
@@ -537,9 +537,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -569,7 +569,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -633,7 +633,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/install/$var_install.sh)" || exit
 
 }
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -537,9 +537,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/tteck/Proxmox/main/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -569,7 +569,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -633,7 +633,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/dsiebel/Proxmox/zoraxy-prebuilt/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/tteck/Proxmox/main/install/$var_install.sh)" || exit
 
 }
 


### PR DESCRIPTION
## Description

After #3952 and #3963 and some frustration on my end, I decided not to give up on this, yet.

This PR changes the install source of Zoraxy from `git clone` and `go build`
to installing the [pre-built binaries from their release page](https://github.com/tobychui/zoraxy/releases). This saves time and resources during install and should keep the install more stable.
The script filters for releases named `x.y.z`, ignoring any beta-, candidate- or docker-only releases (e.g. [v3.1.1r3](https://github.com/tobychui/zoraxy/releases/tag/v3.1.1r3)).

I removed anything that was commented on in previous PRs in the hopes to get this merged more easily.

Fixes #3808, #3083, #3945

## Type of change

Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Documentation update required (this change requires an update to the documentation)

